### PR TITLE
[Generator] Add Server Rules Documentation Generator.

### DIFF
--- a/docs/server/operation/server-rules.md
+++ b/docs/server/operation/server-rules.md
@@ -8,9 +8,9 @@ description: >-
 
 ### Editing rules
 
-To edit rules, you can use the #rules set &lt;key&gt; &lt;value&gt; command to set a rule. 
+To edit rules, you can use the [`#rules set [Name] [Value]`](https://docs.eqemu.io/server/operation/in-game-command-reference) command to set a rule. 
 
-You can then use #reloadallrules to force all zones to reload the new rules. 
+You can then use [`#reload rules`](https://docs.eqemu.io/server/operation/loading-server-data/) to force all zones to reload the new rules. 
 
 !!! warning
       The `notes` field in the database is set by the server software.  If you adjust the values in the field, they will be overwritten and restored to default values when you update your server binaries.
@@ -20,554 +20,818 @@ You can then use #reloadallrules to force all zones to reload the new rules.
       If you would like to improve upon the descriptions or notes in the Server Rules table, please submit a pull request on the [ruletypes](https://github.com/EQEmu/Server/blob/master/common/ruletypes.h) header file.
 
 
-| **Type** | **Category** | **Name** | **Default Value** | **Description** |
-| :--- | :--- | :--- | :--- | :--- |
-| Integer | Character | MaxLevel | 65 |  |
-| Boolean | Character | PerCharacterQglobalMaxLevel | FALSE | This will check for qglobal 'CharMaxLevel' character qglobal (Type 5), if player tries to level beyond that point, it will not go beyond that level |
-| Integer | Character | MaxExpLevel | 0 | Sets the Max Level attainable via Experience |
-| Integer | Character | DeathExpLossLevel | 10 | Any level greater than this will lose exp on death |
-| Integer | Character | DeathExpLossMaxLevel | 255 | Any level greater than this will no longer lose exp on death |
-| Integer | Character | DeathItemLossLevel | 10 |  |
-| Integer | Character | DeathExpLossMultiplier | 3 | Adjust how much exp is lost |
-| Boolean | Character | UseDeathExpLossMult | FALSE | Adjust to use the above multiplier or to use code default. |
-| Integer | Character | CorpseDecayTimeMS | 10800000 |  |
-| Integer | Character | CorpseResTimeMS | 10800000 | time before cant res corpse(3 hours |
-| Boolean | Character | LeaveCorpses | TRUE |  |
-| Boolean | Character | LeaveNakedCorpses | FALSE |  |
-| Integer | Character | MaxDraggedCorpses | 2 |  |
-| Decimal | Character | DragCorpseDistance | 400 | If the corpse is &lt;= this distance from the player, it won't move |
-| Decimal | Character | ExpMultiplier | 0.5 |  |
-| Decimal | Character | AAExpMultiplier | 0.5 |  |
-| Decimal | Character | GroupExpMultiplier | 0.5 |  |
-| Decimal | Character | RaidExpMultiplier | 0.2 |  |
-| Boolean | Character | UseXPConScaling | TRUE |  |
-| Integer | Character | ShowExpValues | 0 | 0 - normal, 1 - Show raw experience values, 2 - Show raw experience values AND percent. |
-| Integer | Character | LightBlueModifier | 40 |  |
-| Integer | Character | BlueModifier | 90 |  |
-| Integer | Character | WhiteModifier | 100 |  |
-| Integer | Character | YellowModifier | 125 |  |
-| Integer | Character | RedModifier | 150 |  |
-| Integer | Character | AutosaveIntervalS | 300 | 0=disabled |
-| Integer | Character | HPRegenMultiplier | 100 |  |
-| Integer | Character | ManaRegenMultiplier | 100 |  |
-| Integer | Character | EnduranceRegenMultiplier | 100 |  |
-| Integer | Character | ConsumptionMultiplier | 100 | item's hunger restored = this value * item's food level, 100 = normal, 50 = people eat 2x as fast, 200 = people eat 2x as slow |
-| Boolean | Character | HealOnLevel | FALSE |  |
-| Boolean | Character | FeignKillsPet | FALSE |  |
-| Integer | Character | ItemManaRegenCap | 15 |  |
-| Integer | Character | ItemHealthRegenCap | 35 |  |
-| Integer | Character | ItemDamageShieldCap | 30 |  |
-| Integer | Character | ItemAccuracyCap | 150 |  |
-| Integer | Character | ItemAvoidanceCap | 100 |  |
-| Integer | Character | ItemCombatEffectsCap | 100 |  |
-| Integer | Character | ItemShieldingCap | 35 |  |
-| Integer | Character | ItemSpellShieldingCap | 35 |  |
-| Integer | Character | ItemDoTShieldingCap | 35 |  |
-| Integer | Character | ItemStunResistCap | 35 |  |
-| Integer | Character | ItemStrikethroughCap | 35 |  |
-| Integer | Character | ItemATKCap | 250 |  |
-| Integer | Character | ItemHealAmtCap | 250 |  |
-| Integer | Character | ItemSpellDmgCap | 250 |  |
-| Integer | Character | ItemClairvoyanceCap | 250 |  |
-| Integer | Character | ItemDSMitigationCap | 50 |  |
-| Integer | Character | ItemEnduranceRegenCap | 15 |  |
-| Integer | Character | ItemExtraDmgCap | 150 | Cap for bonuses to melee skills like Bash, Frenzy, etc |
-| Integer | Character | HasteCap | 100 | Haste cap for non-v3(overhaste) haste. |
-| Integer | Character | SkillUpModifier | 100 | skill ups are at 100% |
-| Boolean | Character | SharedBankPlat | FALSE | off by default to prevent duping for now |
-| Boolean | Character | BindAnywhere | FALSE |  |
-| Integer | Character | RestRegenPercent | 0 | 0 to enable rest state bonus HP and mana regen.  Set to &gt;0 to enable rest state bonus HP and mana regen. |
-| Integer | Character | RestRegenTimeToActivate | 30 | Time in seconds for rest state regen to kick in. |
-| Integer | Character | RestRegenRaidTimeToActivate | 300 | Time in seconds for rest state regen to kick in with a raid target. |
-| Boolean | Character | RestRegenEndurance | FALSE | Whether rest regen will work for endurance or not. |
-| Integer | Character | KillsPerGroupLeadershipAA | 250 | Number of dark blues or above per Group Leadership AA |
-| Integer | Character | KillsPerRaidLeadershipAA | 250 | Number of dark blues or above per Raid Leadership AA |
-| Integer | Character | MaxFearDurationForPlayerCharacter | 4 | 4 tics, each tic calculates every 6 seconds. |
-| Integer | Character | MaxCharmDurationForPlayerCharacter | 15 |  |
-| Integer | Character | BaseHPRegenBonusRaces | 4352 | a bitmask of race(s) that receive the regen bonus. Iksar (4096) & Troll (256) = 4352. see common/races.h for the bitmask values |
-| Boolean | Character | SoDClientUseSoDHPManaEnd | FALSE | Setting this to true will allow SoD clients to use the SoD HP/Mana/End formulas and previous clients will use the old formulas |
-| Boolean | Character | UseRaceClassExpBonuses | TRUE | Setting this to true will enable Class and Racial experience rate bonuses |
-| Boolean | Character | UseOldRaceExpPenalties | FALSE | Setting this to true will enable racial exp penalties for Iksar, Troll, Ogre, and Barbarian, as well as the bonus for Halflings |
-| Boolean | Character | UseOldClassExpPenalties | FALSE | Setting this to true will enable old class exp penalties for Paladin, SK, Ranger, Bard, Monk, Wizard, Enchanter, Magician, and Necromancer, as well as the bonus for Rogues and Warriors |
-| Boolean | Character | RespawnFromHover | FALSE | Use Respawn window, or not. |
-| Integer | Character | RespawnFromHoverTimer | 300 | Respawn Window countdown timer, in SECONDS |
-| Boolean | Character | UseNewStatsWindow | TRUE | New stats window shows everything |
-| Boolean | Character | ItemCastsUseFocus | FALSE | If true, this allows item clickies to use focuses that have limited max levels on them |
-| Integer | Character | MinStatusForNoDropExemptions | 80 | This allows status x and higher to trade no drop items. |
-| Integer | Character | SkillCapMaxLevel | 75 | Sets the Max Level used for Skill Caps (from skill_caps table). -1 makes it use MaxLevel rule value. It is set to 75 because PEQ only has skillcaps up to that level, and grabbing the players' skill past 75 will return 0, breaking all skills past that level. This helps servers with obsurd level caps (75+ level cap) function without any modifications. |
-| Integer | Character | StatCap | 0 |  |
-| Boolean | Character | CheckCursorEmptyWhenLooting | TRUE | If true, a player cannot loot a corpse (player or NPC) with an item on their cursor |
-| Boolean | Character | MaintainIntoxicationAcrossZones | TRUE | If true, alcohol effects are maintained across zoning and logging out/in. |
-| Boolean | Character | EnableDiscoveredItems | TRUE | If enabled, it enables EVENT_DISCOVER_ITEM and also saves character names and timestamps for the first time an item is discovered. |
-| Boolean | Character | EnableXTargetting | TRUE | Enable Extended Targetting Window, for users with UF and later clients. |
-| Boolean | Character | KeepLevelOverMax | FALSE | Don't delevel a character that has somehow gone over the level cap |
-| Integer | Character | FoodLossPerUpdate | 35 | How much food/water you lose per stamina update |
-| Integer | Character | BaseInstrumentSoftCap | 36 | Softcap for instrument mods, 36 commonly referred to as "3.6" as well. |
-| Boolean | Character | UseSpellFileSongCap | TRUE | When they removed the AA that increased the cap they removed the above and just use the spell field |
-| Integer | Character | BaseRunSpeedCap | 158 | Base Run Speed Cap, on live it's 158% which will give you a runspeed of 1.580 hard capped to 225. |
-| Integer | Character | OrnamentationAugmentType | 20 | Ornamentation Augment Type |
-| Decimal | Character | EnvironmentDamageMulipliter | 1 |  |
-| Boolean | Character | UnmemSpellsOnDeath | TRUE |  |
-| Integer | Character | TradeskillUpAlchemy | 2 | Alchemy skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpBaking | 2 | Baking skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpBlacksmithing | 2 | Blacksmithing skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpBrewing | 3 | Brewing skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpFletching | 2 | Fletching skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpJewelcrafting | 2 | Jewelcrafting skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpMakePoison | 2 | Make Poison skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpPottery | 4 | Pottery skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpResearch | 1 | Research skillup rate adjust. Lower is faster. |
-| Integer | Character | TradeskillUpTinkering | 2 | Tinkering skillup rate adjust. Lower is faster. |
-| Boolean | Character | SpamHPUpdates | FALSE | if your server has stupid amounts of HP that causes client display issues, turn this on! |
-| Boolean | Character | MarqueeHPUpdates | FALSE | Will show Health % in center of screen &lt; 100% |
-| Integer | Character | IksarCommonTongue | 95 | 95 By default (live-like? |
-| Integer | Character | OgreCommonTongue | 95 | 95 By default (live-like? |
-| Integer | Character | TrollCommonTongue | 95 | 95 By default (live-like? |
-| Boolean | Character | ActiveInvSnapshots | FALSE | Takes a periodic snapshot of inventory contents from online players |
-| Integer | Character | InvSnapshotMinIntervalM | 180 | Minimum time (in minutes) between inventory snapshots |
-| Integer | Character | InvSnapshotMinRetryM | 30 | Time (in minutes) to re-attempt an inventory snapshot after a failure |
-| Integer | Character | InvSnapshotHistoryD | 30 | Time (in days) to keep snapshot entries |
-| Boolean | Character | RestrictSpellScribing | FALSE | Restricts spell scribing to allowable races/classes of spell scroll, if true |
-| Boolean | Character | UseStackablePickPocketing | TRUE | Allows stackable pickpocketed items to stack instead of only being allowed in empty inventory slots |
-| Boolean | Character | EnableAvoidanceCap | FALSE |  |
-| Integer | Character | AvoidanceCap | 750 | 750 Is a pretty good value, seen people dodge all attacks beyond 1,000 Avoidance |
-| Boolean | Character | AllowMQTarget | FALSE | Disables putting players in the 'hackers' list for targeting beyond the clip plane or attempting to target something untargetable |
-| Boolean | Character | UseOldBindWound | FALSE | Uses the original bind wound behavior |
-| Boolean | Character | GrantHoTTOnCreate | FALSE | Grant Health of Target's Target leadership AA on character creation |
-| Integer | Expansion | CurrentExpansion | -1 | Sets which server side expansion is enabled. See [../../../../developer/project-peq-expansions/expansion-content-filtering](../../../../developer/project-peq-expansions/expansion-content-filtering) for more details. |
-| Integer | Mercs | SuspendIntervalMS | 10000 |  |
-| Integer | Mercs | UpkeepIntervalMS | 180000 |  |
-| Integer | Mercs | SuspendIntervalS | 10 |  |
-| Integer | Mercs | UpkeepIntervalS | 180 |  |
-| Boolean | Mercs | AllowMercs | FALSE |  |
-| Boolean | Mercs | ChargeMercPurchaseCost | FALSE |  |
-| Boolean | Mercs | ChargeMercUpkeepCost | FALSE |  |
-| Integer | Mercs | AggroRadius | 100 | Determines the distance from which a merc will aggro group member's target(also used to determine the distance at which a healer merc will begin healing a group member |
-| Integer | Mercs | AggroRadiusPuller | 25 | Determines the distance from which a merc will aggro group member's target, if they have the group role of puller (also used to determine the distance at which a healer merc will begin healing a group member, if they have the group role of puller |
-| Integer | Mercs | ResurrectRadius | 50 | Determines the distance from which a healer merc will attempt to resurrect a group member's corpse |
-| Integer | Mercs | ScaleRate | 100 |  |
-| Integer | Guild | MaxMembers | 2048 |  |
-| Boolean | Guild | PlayerCreationAllowed | FALSE | Allow players to create a guild using the window in Underfoot+ |
-| Integer | Guild | PlayerCreationLimit | 1 | Only allow use of the UF+ window if the account has &lt; than this number of guild leaders on it |
-| Integer | Guild | PlayerCreationRequiredStatus | 0 | Required admin status. |
-| Integer | Guild | PlayerCreationRequiredLevel | 0 | Required Level of the player attempting to create the guild. |
-| Integer | Guild | PlayerCreationRequiredTime | 0 | Required Time Entitled On Account (in Minutes) to create the guild. |
-| Integer | Skills | MaxTrainTradeskills | 21 |  |
-| Boolean | Skills | UseLimitTradeskillSearchSkillDiff | TRUE |  |
-| Integer | Skills | MaxTradeskillSearchSkillDiff | 50 |  |
-| Integer | Skills | MaxTrainSpecializations | 50 | Max level a GM trainer will train casting specializations |
-| Integer | Skills | SwimmingStartValue | 100 |  |
-| Boolean | Skills | TrainSenseHeading | FALSE |  |
-| Integer | Skills | SenseHeadingStartValue | 200 |  |
-| Decimal | Pets | AttackCommandRange | 150 |  |
-| Boolean | Pets | UnTargetableSwarmPet | FALSE |  |
-| Decimal | Pets | PetPowerLevelCap | 10 | Max number of levels your pet can go up with pet power |
-| Integer | GM | MinStatusToSummonItem | 250 |  |
-| Integer | GM | MinStatusToZoneAnywhere | 250 |  |
-| Integer | World | ZoneAutobootTimeoutMS | 60000 |  |
-| Integer | World | ClientKeepaliveTimeoutMS | 65000 |  |
-| Boolean | World | UseBannedIPsTable | FALSE | Toggle whether or not to check incoming client connections against the Banned_IPs table. Set this value to false to disable this feature. |
-| Boolean | World | EnableTutorialButton | TRUE |  |
-| Boolean | World | EnableReturnHomeButton | TRUE |  |
-| Integer | World | MaxLevelForTutorial | 10 |  |
-| Integer | World | TutorialZoneID | 189 |  |
-| Integer | World | GuildBankZoneID | 345 |  |
-| Integer | World | MinOfflineTimeToReturnHome | 21600 | 21600 seconds is 6 Hours |
-| Integer | World | MaxClientsPerIP | -1 | Maximum number of clients allowed to connect per IP address if account status is &lt; AddMaxClientsStatus. Default value: -1 (feature disabled) |
-| Integer | World | ExemptMaxClientsStatus | -1 | #ERROR! |
-| Integer | World | AddMaxClientsPerIP | -1 | Maximum number of clients allowed to connect per IP address if account status is &lt; ExemptMaxClientsStatus. Default value: -1 (feature disabled |
-| Integer | World | AddMaxClientsStatus | -1 | #ERROR! |
-| Boolean | World | MaxClientsSetByStatus | FALSE | MaxClientsPerIP.  If True, IP Limiting will be set to the status on the account as long as the status is &gt; MaxClientsPerIP |
-| Boolean | World | EnableIPExemptions | FALSE | If True, ip_exemptions table is used, if there is no entry for the IP it will default to RuleI(World:MaxClientsPerIP) |
-| Boolean | World | ClearTempMerchantlist | TRUE | Clears temp merchant items when world boots. |
-| Boolean | World | DeleteStaleCorpeBackups | TRUE | Deletes stale corpse backups older than 2 weeks. |
-| Integer | World | AccountSessionLimit | -1 | Max number of characters allowed on at once from a single account (-1 is disabled |
-| Integer | World | ExemptAccountLimitStatus | -1 | Min status required to be exempt from multi-session per account limiting (-1 is disabled |
-| Boolean | World | GMAccountIPList | FALSE | Check ip list against GM Accounts, AntiHack GM Accounts. |
-| Integer | World | MinGMAntiHackStatus | 1 | Minimum GM status to check against AntiHack list |
-| Integer | World | SoFStartZoneID | -1 | Sets the Starting Zone for SoF Clients separate from Titanium Clients (-1 is disabled |
-| Integer | World | TitaniumStartZoneID | -1 | Sets the Starting Zone for Titanium Clients (-1 is disabled). Replaces the old method. |
-| Integer | World | ExpansionSettings | 16383 | Sets the expansion settings for the server, This is sent on login to world and affects client expansion settings. Defaults to all expansions enabled up to TSS. |
-| Boolean | World | UseClientBasedExpansionSettings | TRUE | if true it will overrule World:ExpansionSettings and set someone's expansion based on the client they're using |
-| Integer | World | PVPSettings | 0 | Sets the PVP settings for the server, 1 = Rallos Zek RuleSet, 2 = Tallon/Vallon Zek Ruleset, 4 = Sullon Zek Ruleset, 6 = Discord Ruleset, anything above 6 is the Discord Ruleset without the no-drop restrictions removed. TODO: Edit IsAttackAllowed in Zone to accomodate for these rules. |
-| Boolean | World | IsGMPetitionWindowEnabled | FALSE |  |
-| Integer | World | FVNoDropFlag | 0 | Sets the Firiona Vie settings on the client. If set to 2, the flag will be set for GMs only, allowing trading of no-drop items. |
-| Boolean | World | IPLimitDisconnectAll | FALSE |  |
-| Integer | World | TellQueueSize | 20 |  |
-| Integer | Zone | NPCPositonUpdateTicCount | 32 | ms between intervals of sending a position update to the entire zone. |
-| Integer | Zone | ClientLinkdeadMS | 180000 | the time a client remains link dead on the server after a sudden disconnection |
-| Integer | Zone | GraveyardTimeMS | 1200000 | ms time until a player corpse is moved to a zone's graveyard, if one is specified for the zone |
-| Boolean | Zone | EnableShadowrest | 1 | enables or disables the shadowrest zone feature for player corpses. Default is turned on. |
-| Boolean | Zone | UsePlayerCorpseBackups | TRUE | Keeps backups of player corpses. |
-| Integer | Zone | MQWarpExemptStatus | -1 | Required status level to exempt the MQWarpDetector. Set to -1 to disable this feature. |
-| Integer | Zone | MQZoneExemptStatus | -1 | Required status level to exempt the MQZoneDetector. Set to -1 to disable this feature. |
-| Integer | Zone | MQGateExemptStatus | -1 | Required status level to exempt the MQGateDetector. Set to -1 to disable this feature. |
-| Integer | Zone | MQGhostExemptStatus | -1 | Required status level to exempt the MGhostDetector. Set to -1 to disable this feature. |
-| Boolean | Zone | EnableMQWarpDetector | TRUE | Enable the MQWarp Detector. Set to False to disable this feature. |
-| Boolean | Zone | EnableMQZoneDetector | TRUE | Enable the MQZone Detector. Set to False to disable this feature. |
-| Boolean | Zone | EnableMQGateDetector | TRUE | Enable the MQGate Detector. Set to False to disable this feature. |
-| Boolean | Zone | EnableMQGhostDetector | TRUE | Enable the MQGhost Detector. Set to False to disable this feature. |
-| Decimal | Zone | MQWarpDetectionDistanceFactor | 9 | clients move at 4.4 about if in a straight line but with movement and to acct for lag we raise it a bit |
-| Boolean | Zone | MarkMQWarpLT | FALSE |  |
-| Integer | Zone | AutoShutdownDelay | 5000 | How long a dynamic zone stays loaded while empty |
-| Integer | Zone | PEQZoneReuseTime | 900 | How long, in seconds, until you can reuse the #peqzone command. |
-| Integer | Zone | PEQZoneDebuff1 | 4454 | First debuff casted by #peqzone Default is Cursed Keeper's Blight. |
-| Integer | Zone | PEQZoneDebuff2 | 2209 | Second debuff casted by #peqzone Default is Tendrils of Apathy. |
-| Boolean | Zone | UsePEQZoneDebuffs | TRUE | Will determine if #peqzone will debuff players or not when used. |
-| Decimal | Zone | HotZoneBonus | 0.75 |  |
-| Integer | Zone | ReservedInstances | 30 | Will reserve this many instance ids for globals... probably not a good idea to change this while a server is running. |
-| Integer | Zone | EbonCrystalItemID | 40902 |  |
-| Integer | Zone | RadiantCrystalItemID | 40903 |  |
-| Boolean | Zone | LevelBasedEXPMods | FALSE | Allows you to use the level_exp_mods table in consideration to your players EXP hits |
-| Integer | Zone | WeatherTimer | 600 | Weather timer when no duration is available |
-| Boolean | Zone | EnableLoggedOffReplenishments | TRUE |  |
-| Integer | Zone | MinOfflineTimeToReplenishments | 21600 | 21600 seconds is 6 Hours |
-| Boolean | Zone | UseZoneController | TRUE | Enables the ability to use persistent quest based zone controllers (zone_controller.pl/lua |
-| Boolean | Zone | EnableZoneControllerGlobals | FALSE | Enables the ability to use quest globals with the zone controller NPC |
-| Boolean | Map | FixPathingZWhenLoading | TRUE | increases zone boot times a bit to reduce hopping. |
-| Boolean | Map | FixPathingZAtWaypoints | FALSE | alternative to `WhenLoading`, accomplishes the same thing but does it at each waypoint instead of once at boot time. |
-| Boolean | Map | FixPathingZWhenMoving | FALSE | very CPU intensive, but helps hopping with widely spaced waypoints. |
-| Boolean | Map | FixPathingZOnSendTo | FALSE | try to repair Z coords in the SendTo routine as well. |
-| Decimal | Map | FixPathingZMaxDeltaMoving | 20 | at runtime while pathing: max change in Z to allow the BestZ code to apply. |
-| Decimal | Map | FixPathingZMaxDeltaWaypoint | 20 | at runtime at each waypoint: max change in Z to allow the BestZ code to apply. |
-| Decimal | Map | FixPathingZMaxDeltaSendTo | 20 | at runtime in SendTo: max change in Z to allow the BestZ code to apply. |
-| Decimal | Map | FixPathingZMaxDeltaLoading | 45 | while loading each waypoint: max change in Z to allow the BestZ code to apply. |
-| Integer | Map | FindBestZHeightAdjust | 1 | Adds this to the current Z before seeking the best Z position |
-| Boolean | Pathing | Aggro | TRUE | Enable pathing for aggroed mobs. |
-| Boolean | Pathing | AggroReturnToGrid | TRUE | Enable pathing for aggroed roaming mobs returning to their previous waypoint. |
-| Boolean | Pathing | Guard | TRUE | Enable pathing for mobs moving to their guard point. |
-| Boolean | Pathing | Find | TRUE | Enable pathing for FindPerson requests from the client. |
-| Boolean | Pathing | Fear | TRUE | Enable pathing for fear |
-| Decimal | Pathing | ZDiffThreshold | 10 | If a mob las LOS to it's target, it will run to it if the Z difference is &lt; this. |
-| Integer | Pathing | LOSCheckFrequency | 1000 | A mob will check for LOS to it's target this often (milliseconds). |
-| Integer | Pathing | RouteUpdateFrequencyShort | 1000 | How often a new route will be calculated if the target has moved. |
-| Integer | Pathing | RouteUpdateFrequencyLong | 5000 | How often a new route will be calculated if the target has moved. |
-| Integer | Pathing | RouteUpdateFrequencyNodeCount | 5 |  |
-| Decimal | Pathing | MinDistanceForLOSCheckShort | 40000 | (NoRoot). While following a path, only check for LOS to target within this distance. |
-| Decimal | Pathing | MinDistanceForLOSCheckLong | 1000000 | (NoRoot). Min distance when initially attempting to acquire the target. |
-| Integer | Pathing | MinNodesLeftForLOSCheck | 4 | Only check for LOS when we are down to this many path nodes left to run. |
-| Integer | Pathing | MinNodesTraversedForLOSCheck | 3 | Only check for LOS after we have traversed this many path nodes. |
-| Integer | Pathing | CullNodesFromStart | 1 | Checks LOS from Start point to second node for this many nodes and removes first node if there is LOS |
-| Integer | Pathing | CullNodesFromEnd | 1 | Checks LOS from End point to second to last node for this many nodes and removes last node if there is LOS |
-| Decimal | Pathing | CandidateNodeRangeXY | 400 | When searching for path start/end nodes, only nodes within this range will be considered. |
-| Decimal | Pathing | CandidateNodeRangeZ | 10 | When searching for path start/end nodes, only nodes within this range will be considered. |
-| Boolean | Watermap | CheckWaypointsInWaterWhenLoading | FALSE | Does not apply BestZ as waypoints are loaded if they are in water |
-| Boolean | Watermap | CheckForWaterAtWaypoints | FALSE | Check if a mob has moved into/out of water when at waypoints and sets flymode |
-| Boolean | Watermap | CheckForWaterWhenMoving | FALSE | Checks if a mob has moved into/out of water each time it's loc is recalculated |
-| Boolean | Watermap | CheckForWaterOnSendTo | FALSE | Checks if a mob has moved into/out of water on SendTo |
-| Boolean | Watermap | CheckForWaterWhenFishing | FALSE | Only lets a player fish near water (if a water map exists for the zone |
-| Decimal | Watermap | FishingRodLength | 30 | How far in front of player water must be for fishing to work |
-| Decimal | Watermap | FishingLineLength | 100 | If water is more than this far below the player, it is considered too far to fish |
-| Decimal | Watermap | FishingLineStepSize | 1 | Basic step size for fishing calc, too small and it will eat cpu, too large and it will miss potential water |
-| Integer | Spells | AutoResistDiff | 15 |  |
-| Decimal | Spells | ResistChance | 2 | chance to resist given no resists and same level |
-| Decimal | Spells | ResistMod | 0.4 | multiplier, chance to resist = this * ResistAmount |
-| Decimal | Spells | PartialHitChance | 0.7 | The chance when a spell is resisted that it will partial hit. |
-| Decimal | Spells | PartialHitChanceFear | 0.25 | The chance when a fear spell is resisted that it will partial hit. |
-| Integer | Spells | BaseCritChance | 0 | base % chance that everyone has to crit a spell |
-| Integer | Spells | BaseCritRatio | 100 | base % bonus to damage on a successful spell crit. 100 = 2x damage |
-| Integer | Spells | WizCritLevel | 12 | level wizards first get spell crits |
-| Integer | Spells | WizCritChance | 7 | wiz's crit chance, on top of BaseCritChance |
-| Integer | Spells | WizCritRatio | 0 | wiz's crit bonus, on top of BaseCritRatio (should be 0 for Live-like |
-| Integer | Spells | ResistPerLevelDiff | 85 | 8.5 resist per level difference. |
-| Integer | Spells | TranslocateTimeLimit | 0 | If not zero, time in seconds to accept a Translocate. |
-| Integer | Spells | SacrificeMinLevel | 46 | first level Sacrifice will work on |
-| Integer | Spells | SacrificeMaxLevel | 69 | last level Sacrifice will work on |
-| Integer | Spells | SacrificeItemID | 9963 | Item ID of the item Sacrifice will return (defaults to an EE |
-| Boolean | Spells | EnableSpellGlobals | FALSE | If Enabled, spells check the spell_globals table and compare character data from the quest globals before allowing that spell to scribe with scribespells |
-| Integer | Spells | MaxBuffSlotsNPC | 25 |  |
-| Integer | Spells | MaxSongSlotsNPC | 10 |  |
-| Integer | Spells | MaxDiscSlotsNPC | 1 |  |
-| Integer | Spells | MaxTotalSlotsNPC | 36 |  |
-| Integer | Spells | MaxTotalSlotsPET | 30 | do not set this higher than 25 until the player profile is removed from the blob |
-| Boolean | Spells | EnableBlockedBuffs | TRUE |  |
-| Integer | Spells | ReflectType | 1 | 0 = disabled, 1 = single target player spells only, 2 = all player spells, 3 = all single target spells, 4 = all spells |
-| Integer | Spells | VirusSpreadDistance | 30 | The distance a viral spell will jump to its next victim |
-| Boolean | Spells | LiveLikeFocusEffects | TRUE | Determines whether specific healing, dmg and mana reduction focuses are randomized |
-| Integer | Spells | BaseImmunityLevel | 55 | The level that targets start to be immune to stun, fear and mez spells with a max level of 0. |
-| Boolean | Spells | NPCIgnoreBaseImmunity | TRUE | Whether or not NPCs get to ignore the BaseImmunityLevel for their spells. |
-| Decimal | Spells | AvgSpellProcsPerMinute | 6 | Adjust rate for sympathetic spell procs |
-| Integer | Spells | ResistFalloff | 67 | Max that level that will adjust our resist chance based on level modifiers |
-| Integer | Spells | CharismaEffectiveness | 10 | Deterimes how much resist modification charisma applies to charm/pacify checks. Default 10 CHA = -1 resist mod. |
-| Integer | Spells | CharismaEffectivenessCap | 255 | Deterimes how much resist modification charisma applies to charm/pacify checks. Default 10 CHA = -1 resist mod. |
-| Boolean | Spells | CharismaCharmDuration | FALSE | Allow CHA resist mod to extend charm duration. |
-| Integer | Spells | CharmBreakCheckChance | 25 | Determines chance for a charm break check to occur each buff tick. |
-| Integer | Spells | MaxCastTimeReduction | 50 | Max percent your spell cast time can be reduced by spell haste |
-| Integer | Spells | RootBreakFromSpells | 55 | Chance for root to break when cast on. |
-| Integer | Spells | DeathSaveCharismaMod | 3 | Determines how much charisma effects chance of death save firing. |
-| Integer | Spells | DivineInterventionHeal | 8000 | Divine intervention heal amount. |
-| Integer | Spells | AdditiveBonusWornType | 0 | Calc worn bonuses to add together (instead of taking highest) if set to THIS worn type. (2=Will covert live items automatically |
-| Boolean | Spells | UseCHAScribeHack | FALSE | ScribeSpells and TrainDiscs quest functions will ignore entries where field 12 is CHA. What's the best way to do this? |
-| Boolean | Spells | BuffLevelRestrictions | TRUE | Buffs will not land on low level toons like live |
-| Integer | Spells | RootBreakCheckChance | 70 | Determines chance for a root break check to occur each buff tick. |
-| Integer | Spells | FearBreakCheckChance | 70 | Determines chance for a fear break check to occur each buff tick. |
-| Integer | Spells | SuccorFailChance | 2 | Determines chance for a succor spell not to teleport an invidual player |
-| Integer | Spells | FRProjectileItem_Titanium | 1113 | Item id for Titanium clients for Fire 'spell projectile'. |
-| Integer | Spells | FRProjectileItem_SOF | 80684 | Item id for SOF clients for Fire 'spell projectile'. |
-| Integer | Spells | FRProjectileItem_NPC | 80684 | Item id for NPC Fire 'spell projectile'. |
-| Boolean | Spells | UseLiveSpellProjectileGFX | FALSE | Use spell projectile graphics set in the spells_new table (player_1). Server must be using UF+ spell file. |
-| Boolean | Spells | FocusCombatProcs | FALSE | Allow all combat procs to receive focus effects. |
-| Boolean | Spells | PreNerfBardAEDoT | FALSE | Allow bard AOE dots to damage targets when moving. |
-| Integer | Spells | AI_SpellCastFinishedFailRecast | 800 | AI spell recast time(MS) when an spell is cast but fails (ie stunned). |
-| Integer | Spells | AI_EngagedNoSpellMinRecast | 500 | AI spell recast time(MS) check when no spell is cast while engaged. (min time in random |
-| Integer | Spells | AI_EngagedNoSpellMaxRecast | 1000 | AI spell recast time(MS) check when no spell is cast engaged.(max time in random |
-| Integer | Spells | AI_EngagedBeneficialSelfChance | 100 | Chance during first AI Cast check to do a beneficial spell on self. |
-| Integer | Spells | AI_EngagedBeneficialOtherChance | 25 | Chance during second AI Cast check to do a beneficial spell on others. |
-| Integer | Spells | AI_EngagedDetrimentalChance | 20 | Chance during third AI Cast check to do a determental spell on others. |
-| Integer | Spells | AI_PursueNoSpellMinRecast | 500 | AI spell recast time(MS) check when no spell is cast while chasing target. (min time in random |
-| Integer | Spells | AI_PursueNoSpellMaxRecast | 2000 | AI spell recast time(MS) check when no spell is cast while chasing target. (max time in random |
-| Integer | Spells | AI_PursueDetrimentalChance | 90 | Chance while chasing target to cast a detrimental spell. |
-| Integer | Spells | AI_IdleNoSpellMinRecast | 6000 | AI spell recast time(MS) check when no spell is cast while idle. (min time in random |
-| Integer | Spells | AI_IdleNoSpellMaxRecast | 60000 | AI spell recast time(MS) check when no spell is cast while chasing target. (max time in random |
-| Integer | Spells | AI_IdleBeneficialChance | 100 | Chance while idle to do a beneficial spell on self or others. |
-| Boolean | Spells | SHDProcIDOffByOne | TRUE | pre June 2009 SHD spell procs were off by 1, they stopped doing this in June 2009 (so UF+ spell files need this false |
-| Boolean | Spells | Jun182014HundredHandsRevamp | FALSE | this should be true for if you import a spell file newer than June 18, 2014 |
-| Boolean | Spells | SwarmPetTargetLock | FALSE | Use old method of swarm pets target locking till target dies then despawning. |
-| Boolean | Spells | NPC_UseFocusFromSpells | TRUE | Allow npcs to use most spell derived focus effects. |
-| Boolean | Spells | NPC_UseFocusFromItems | FALSE | Allow npcs to use most item derived focus effects. |
-| Boolean | Spells | UseAdditiveFocusFromWornSlot | FALSE | Allows an additive focus effect to be calculated from worn slot. |
-| Boolean | Spells | AlwaysSendTargetsBuffs | FALSE | ignore LAA level if true |
-| Boolean | Spells | FlatItemExtraSpellAmt | FALSE | allow SpellDmg stat to affect all spells, regardless of cast time/cooldown/etc |
-| Boolean | Spells | IgnoreSpellDmgLvlRestriction | FALSE | ignore the 5 level spread on applying SpellDmg |
-| Boolean | Spells | AllowItemTGB | FALSE | TGB doesn't work with items on live, custom servers want it though |
-| Boolean | Spells | NPCInnateProcOverride | TRUE | NPC innate procs override the target type to single target. |
-| Integer | Combat | MeleeBaseCritChance | 0 | The base crit chance for non warriors, NOTE: This will apply to NPCs as well |
-| Integer | Combat | WarBerBaseCritChance | 3 | The base crit chance for warriors and berserkers, only applies to clients |
-| Integer | Combat | BerserkBaseCritChance | 6 | The bonus base crit chance you get when you're berserk |
-| Integer | Combat | NPCBashKickLevel | 6 | The level that npcs can KICK/BASH |
-| Integer | Combat | NPCBashKickStunChance | 15 | Percent chance that a bash/kick will stun |
-| Integer | Combat | RogueCritThrowingChance | 25 | Rogue throwing crit bonus |
-| Integer | Combat | RogueDeadlyStrikeChance | 80 | Rogue chance throwing from behind crit becomes a deadly strike |
-| Integer | Combat | RogueDeadlyStrikeMod | 2 | Deadly strike modifier to crit damage |
-| Integer | Combat | ClientBaseCritChance | 0 | The base crit chance for all clients, this will stack with warrior's/zerker's crit chance. |
-| Boolean | Combat | UseIntervalAC | TRUE |  |
-| Integer | Combat | PetAttackMagicLevel | 30 |  |
-| Boolean | Combat | EnableFearPathing | TRUE |  |
-| Decimal | Combat | FleeMultiplier | 2 | Determines how quickly a NPC will slow down while fleeing. Decrease multiplier to slow NPC down quicker. |
-| Integer | Combat | FleeHPRatio | 25 | HP % when a NPC begins to flee. |
-| Boolean | Combat | FleeIfNotAlone | FALSE | If false, mobs won't flee if other mobs are in combat with it. |
-| Boolean | Combat | AdjustProcPerMinute | TRUE |  |
-| Decimal | Combat | AvgProcsPerMinute | 2 |  |
-| Decimal | Combat | ProcPerMinDexContrib | 0.075 |  |
-| Decimal | Combat | BaseProcChance | 0.035 |  |
-| Decimal | Combat | ProcDexDivideBy | 11000 |  |
-| Boolean | Combat | AdjustSpecialProcPerMinute | TRUE | Set PPM for special abilities like HeadShot (Live does this as of 4-14 |
-| Decimal | Combat | AvgSpecialProcsPerMinute | 2 | Unclear what best value is atm. |
-| Decimal | Combat | BaseHitChance | 69 |  |
-| Decimal | Combat | NPCBonusHitChance | 26 |  |
-| Decimal | Combat | HitFalloffMinor | 5 | hit will fall off up to 5% over the initial level range |
-| Decimal | Combat | HitFalloffModerate | 7 | hit will fall off up to 7% over the three levels after the initial level range |
-| Decimal | Combat | HitFalloffMajor | 50 | hit will fall off sharply if we're outside the minor and moderate range |
-| Decimal | Combat | HitBonusPerLevel | 1.2 | You gain this % of hit for every level you are above your target |
-| Decimal | Combat | WeaponSkillFalloff | 0.33 | For every weapon skill point that's not maxed you lose this % of hit |
-| Decimal | Combat | ArcheryHitPenalty | 0.25 | Archery has a hit penalty to try to help balance it with the plethora of long term +hit modifiers for it |
-| Decimal | Combat | AgiHitFactor | 0.01 |  |
-| Decimal | Combat | MinChancetoHit | 5 | Minimum % chance to hit with regular melee/ranged |
-| Decimal | Combat | MaxChancetoHit | 95 | Maximum % chance to hit with regular melee/ranged |
-| Integer | Combat | MinRangedAttackDist | 25 | Minimum Distance to use Ranged Attacks |
-| Boolean | Combat | ArcheryBonusRequiresStationary | TRUE | does the 2x archery bonus chance require a stationary npc |
-| Decimal | Combat | ArcheryBaseDamageBonus | 1 | % Modifier to Base Archery Damage (.5 = 50% base damage, 1 = 100%, 2 = 200% |
-| Decimal | Combat | ArcheryNPCMultiplier | 1 | this is multiplied by the regular dmg to get the archery dmg |
-| Boolean | Combat | AssistNoTargetSelf | TRUE | when assisting a target that does not have a target: true = target self, false = leave target as was before assist (false = live like |
-| Integer | Combat | MaxRampageTargets | 3 | max number of people hit with rampage |
-| Integer | Combat | DefaultRampageTargets | 1 | default number of people to hit with rampage |
-| Boolean | Combat | RampageHitsTarget | FALSE | rampage will hit the target if it still has targets left |
-| Integer | Combat | MaxFlurryHits | 2 | max number of extra hits from flurry |
-| Integer | Combat | MonkDamageTableBonus | 5 | % bonus monks get to their damage table calcs |
-| Integer | Combat | FlyingKickBonus | 25 | % Modifier that this skill gets to str and skill bonuses |
-| Integer | Combat | DragonPunchBonus | 20 | % Modifier that this skill gets to str and skill bonuses |
-| Integer | Combat | EagleStrikeBonus | 15 | % Modifier that this skill gets to str and skill bonuses |
-| Integer | Combat | TigerClawBonus | 10 | % Modifier that this skill gets to str and skill bonuses |
-| Integer | Combat | RoundKickBonus | 5 | % Modifier that this skill gets to str and skill bonuses |
-| Integer | Combat | FrenzyBonus | 0 | % Modifier to damage |
-| Integer | Combat | BackstabBonus | 0 | % Modifier to damage |
-| Boolean | Combat | ProcTargetOnly | TRUE | true = procs will only affect our target, false = procs will affect all of our targets |
-| Decimal | Combat | NPCACFactor | 2.25 |  |
-| Integer | Combat | ClothACSoftcap | 75 |  |
-| Integer | Combat | LeatherACSoftcap | 100 |  |
-| Integer | Combat | MonkACSoftcap | 120 |  |
-| Integer | Combat | ChainACSoftcap | 200 |  |
-| Integer | Combat | PlateACSoftcap | 300 |  |
-| Decimal | Combat | AAMitigationACFactor | 3 |  |
-| Decimal | Combat | WarriorACSoftcapReturn | 0.45 |  |
-| Decimal | Combat | KnightACSoftcapReturn | 0.33 |  |
-| Decimal | Combat | LowPlateChainACSoftcapReturn | 0.23 |  |
-| Decimal | Combat | LowChainLeatherACSoftcapReturn | 0.17 |  |
-| Decimal | Combat | CasterACSoftcapReturn | 0.06 |  |
-| Decimal | Combat | MiscACSoftcapReturn | 0.3 |  |
-| Boolean | Combat | OldACSoftcapRules | FALSE | use old softcaps |
-| Boolean | Combat | UseOldDamageIntervalRules | FALSE | use old damage formulas for everything |
-| Decimal | Combat | WarACSoftcapReturn | 0.3448 | new AC returns |
-| Decimal | Combat | ClrRngMnkBrdACSoftcapReturn | 0.303 |  |
-| Decimal | Combat | PalShdACSoftcapReturn | 0.3226 |  |
-| Decimal | Combat | DruNecWizEncMagACSoftcapReturn | 0.2 |  |
-| Decimal | Combat | RogShmBstBerACSoftcapReturn | 0.25 |  |
-| Decimal | Combat | SoftcapFactor | 1.88 |  |
-| Decimal | Combat | ACthac0Factor | 0.55 |  |
-| Decimal | Combat | ACthac20Factor | 0.55 |  |
-| Integer | Combat | HitCapPre20 | 40 | live has it capped at 40 for whatever dumb reason... this is mainly for custom servers |
-| Integer | Combat | HitCapPre10 | 20 | live has it capped at 20, see above :p |
-| Integer | Combat | MinHastedDelay | 400 | how fast we can get with haste. |
-| Decimal | Combat | AvgDefProcsPerMinute | 2 |  |
-| Decimal | Combat | DefProcPerMinAgiContrib | 0.075 | How much agility contributes to defensive proc rate |
-| Integer | Combat | SpecialAttackACBonus | 15 | Percent amount of damage per AC gained for certain special attacks (damage = AC*SpecialAttackACBonus/100). |
-| Integer | Combat | NPCFlurryChance | 20 | Chance for NPC to flurry. |
-| Boolean | Combat | TauntOverLevel | 1 | Allows you to taunt NPC's over warriors level. |
-| Decimal | Combat | TauntSkillFalloff | 0.33 | For every taunt skill point that's not maxed you lose this % chance to taunt. |
-| Boolean | Combat | EXPFromDmgShield | FALSE | Determine if damage from a damage shield counts for EXP gain. |
-| Integer | Combat | MonkACBonusWeight | 15 |  |
-| Integer | Combat | ClientStunLevel | 55 | This is the level where client kicks and bashes can stun the target |
-| Integer | Combat | QuiverHasteCap | 1000 | Quiver haste cap 1000 on live for a while, currently 700 on live |
-| Boolean | Combat | UseArcheryBonusRoll | FALSE | Make the 51+ archery bonus require an actual roll |
-| Integer | Combat | ArcheryBonusChance | 50 |  |
-| Integer | Combat | BerserkerFrenzyStart | 35 |  |
-| Integer | Combat | BerserkerFrenzyEnd | 45 |  |
-| Boolean | Combat | OneProcPerWeapon | TRUE | If enabled, One proc per weapon per round |
-| Boolean | Combat | ProjectileDmgOnImpact | TRUE | If enabled, projectiles (ie arrows) will hit on impact, instead of instantly. |
-| Boolean | Combat | MeleePush | TRUE | enable melee push |
-| Integer | Combat | MeleePushChance | 50 | (NPCs) chance the target will be pushed. Made up, 100 actually isn't that bad |
-| Boolean | Combat | UseLiveCombatRounds | TRUE | turn this false if you don't want to worry about fixing up combat rounds for NPCs |
-| Integer | Combat | NPCAssistCap | 5 | Maxiumium number of NPCs that will assist another NPC at once |
-| Integer | Combat | NPCAssistCapTimer | 6000 | Time in milliseconds a NPC will take to clear assist aggro cap space |
-| Boolean | Combat | UseRevampHandToHand | FALSE | use h2h revamped dmg/delays I believe this was implemented during SoF |
-| Boolean | Combat | ClassicMasterWu | FALSE | classic master wu uses a random special, modern doesn't |
-| Integer | NPC | MinorNPCCorpseDecayTimeMS | 450000 | level&lt;55 |
-| Integer | NPC | MajorNPCCorpseDecayTimeMS | 1500000 | #ERROR! |
-| Integer | NPC | CorpseUnlockTimer | 150000 |  |
-| Integer | NPC | EmptyNPCCorpseDecayTimeMS | 0 |  |
-| Boolean | NPC | UseItemBonusesForNonPets | TRUE |  |
-| Integer | NPC | SayPauseTimeInSec | 5 |  |
-| Integer | NPC | OOCRegen | 0 |  |
-| Boolean | NPC | BuffFriends | FALSE |  |
-| Boolean | NPC | EnableNPCQuestJournal | FALSE |  |
-| Integer | NPC | LastFightingDelayMovingMin | 10000 |  |
-| Integer | NPC | LastFightingDelayMovingMax | 20000 |  |
-| Boolean | NPC | SmartLastFightingDelayMoving | TRUE |  |
-| Boolean | NPC | ReturnNonQuestNoDropItems | FALSE | Returns NO DROP items on NPCs that don't have an EVENT_TRADE sub in their script |
-| Integer | NPC | StartEnrageValue | 9 | % HP that an NPC will begin to enrage |
-| Boolean | NPC | LiveLikeEnrage | FALSE | If set to true then only player controlled pets will enrage |
-| Boolean | NPC | EnableMeritBasedFaction | FALSE | If set to true, faction will given in the same way as experience (solo/group/raid |
-| Integer | NPC | NPCToNPCAggroTimerMin | 500 |  |
-| Integer | NPC | NPCToNPCAggroTimerMax | 6000 |  |
-| Boolean | NPC | UseClassAsLastName | TRUE | Uses class archetype as LastName for npcs with none |
-| Boolean | NPC | NewLevelScaling | TRUE | Better level scaling, use old if new formulas would break your server |
-| Boolean | Aggro | SmartAggroList | TRUE |  |
-| Integer | Aggro | SittingAggroMod | 35 | 35% |
-| Integer | Aggro | MeleeRangeAggroMod | 10 | 10% |
-| Integer | Aggro | CurrentTargetAggroMod | 0 | 0% -- will prefer our current target to any other; makes it harder for our npcs to switch targets. |
-| Integer | Aggro | CriticallyWoundedAggroMod | 100 | 100% |
-| Integer | Aggro | SpellAggroMod | 100 |  |
-| Integer | Aggro | SongAggroMod | 33 |  |
-| Integer | Aggro | PetSpellAggroMod | 10 |  |
-| Decimal | Aggro | TunnelVisionAggroMod | 0.75 | people not currently the top hate generate this much hate on a Tunnel Vision mob |
-| Integer | Aggro | MaxScalingProcAggro | 400 | Set to -1 for no limit. Maxmimum amount of aggro that HP scaling SPA effect in a proc will add. |
-| Integer | Aggro | IntAggroThreshold | 75 | Int &lt;= this will aggro regardless of level difference. |
-| Boolean | Aggro | AllowTickPulling | FALSE | tick pulling is an exploit in an NPC's call for help fixed sometime in 2006 on live |
-| Boolean | Aggro | UseLevelAggro | TRUE | Level 18+ and Undead will aggro regardless of level difference. (this will disabled Rule:IntAggroThreshold if set to true |
-| Boolean | TaskSystem | EnableTaskSystem | TRUE | Globally enable or disable the Task system |
-| Integer | TaskSystem | PeriodicCheckTimer | 5 | Seconds between checks for failed tasks. Also used by the 'Touch' activity |
-| Boolean | TaskSystem | RecordCompletedTasks | TRUE |  |
-| Boolean | TaskSystem | RecordCompletedOptionalActivities | FALSE |  |
-| Boolean | TaskSystem | KeepOneRecordPerCompletedTask | TRUE |  |
-| Boolean | TaskSystem | EnableTaskProximity | TRUE |  |
-| Integer | Bots | AAExpansion | 8 | Bots get AAs through this expansion |
-| Boolean | Bots | AllowCamelCaseNames | FALSE | Allows the use of 'MyBot' type names |
-| Integer | Bots | CommandSpellRank | 1 | Filters bot command spells by rank (1, 2 and 3 are valid filters - any other number allows all ranks |
-| Integer | Bots | CreationLimit | 150 | Number of bots that each account can create |
-| Boolean | Bots | FinishBuffing | FALSE | Allow for buffs to complete even if the bot caster is out of mana. Only affects buffing out of combat. |
-| Boolean | Bots | GroupBuffing | FALSE | Bots will cast single target buffs as group buffs, default is false for single. Does not make single target buffs work for MGB. |
-| Integer | Bots | HealRotationMaxMembers | 24 | Maximum number of heal rotation members |
-| Integer | Bots | HealRotationMaxTargets | 12 | Maximum number of heal rotation targets |
-| Decimal | Bots | ManaRegen | 2 | Adjust mana regen for bots, 1 is fast and higher numbers slow it down 3 is about the same as players. |
-| Boolean | Bots | PreferNoManaCommandSpells | TRUE | Give sorting priority to newer no-mana spells (i.e., 'Bind Affinity' |
-| Boolean | Bots | QuestableSpawnLimit | FALSE | Optional quest method to manage bot spawn limits using the quest_globals name bot_spawn_limit, see: /bazaar/Aediles_Thrall.pl |
-| Boolean | Bots | QuestableSpells | FALSE | Anita Thrall's (Anita_Thrall.pl) Bot Spell Scriber quests. |
-| Integer | Bots | SpawnLimit | 71 | Number of bots a character can have spawned at one time, You + 71 bots is a 12 group raid |
-| Boolean | Bots | BotGroupXP | FALSE | Determines whether client gets xp for bots outside their group. |
-| Boolean | Bots | BotBardUseOutOfCombatSongs | TRUE | Determines whether bard bots use additional out of combat songs (optional script |
-| Boolean | Bots | BotLevelsWithOwner | FALSE | Auto-updates spawned bots as owner levels/de-levels (false is original behavior |
-| Boolean | Bots | BotCharacterLevelEnabled | FALSE | Enables required level to spawn bots |
-| Integer | Bots | BotCharacterLevel | 0 | this value you can spawn bots if BotCharacterLevelEnabled is true.  0 as default (if level &gt; this value you can spawn bots if BotCharacterLevelEnabled is true |
-| Boolean | Chat | ServerWideOOC | TRUE |  |
-| Boolean | Chat | ServerWideAuction | TRUE |  |
-| Boolean | Chat | EnableVoiceMacros | TRUE |  |
-| Boolean | Chat | EnableMailKeyIPVerification | TRUE |  |
-| Boolean | Chat | EnableAntiSpam | TRUE |  |
-| Boolean | Chat | SuppressCommandErrors | FALSE | Do not suppress by default |
-| Integer | Chat | MinStatusToBypassAntiSpam | 100 |  |
-| Integer | Chat | MinimumMessagesPerInterval | 4 |  |
-| Integer | Chat | MaximumMessagesPerInterval | 12 |  |
-| Integer | Chat | MaxMessagesBeforeKick | 20 |  |
-| Integer | Chat | IntervalDurationMS | 60000 |  |
-| Integer | Chat | KarmaUpdateIntervalMS | 1200000 |  |
-| Integer | Chat | KarmaGlobalChatLimit | 72 | amount of karma you need to be able to talk in ooc/auction/chat below the level limit |
-| Integer | Chat | GlobalChatLevelLimit | 8 | level limit you need to of reached to talk in ooc/auction/chat if your karma is too low. |
-| Boolean | Merchant | UsePriceMod | TRUE | Use faction/charisma price modifiers. |
-| Decimal | Merchant | SellCostMod | 1.05 | Modifier for NPC sell price. |
-| Decimal | Merchant | BuyCostMod | 0.95 | Modifier for NPC buy price. |
-| Integer | Merchant | PriceBonusPct | 4 | Determines maximum price bonus from having good faction/CHA. Value is a percent. |
-| Integer | Merchant | PricePenaltyPct | 4 | Determines maximum price penalty from having bad faction/CHA. Value is a percent. |
-| Decimal | Merchant | ChaBonusMod | 3.45 | Determines CHA cap, from 104 CHA. 3.45 is 132 CHA at apprehensive. 0.34 is 400 CHA at apprehensive. |
-| Decimal | Merchant | ChaPenaltyMod | 1.52 | Determines CHA bottom, up to 102 CHA. 1.52 is 37 CHA at apprehensive. 0.98 is 0 CHA at apprehensive. |
-| Boolean | Merchant | EnableAltCurrencySell | TRUE | Enables the ability to resell items to alternate currency merchants |
-| Boolean | Bazaar | AuditTrail | FALSE |  |
-| Integer | Bazaar | MaxSearchResults | 50 |  |
-| Boolean | Bazaar | EnableWarpToTrader | TRUE |  |
-| Integer | Bazaar | MaxBarterSearchResults | 200 | The max results returned in the /barter search |
-| Boolean | Mail | EnableMailSystem | TRUE | If false, client won't bring up the Mail window. |
-| Integer | Mail | ExpireTrash | 0 | Time in seconds. 0 will delete all messages in the trash when the mailserver starts |
-| Integer | Mail | ExpireRead | 31536000 | 1 Year. Set to -1 for never |
-| Integer | Mail | ExpireUnread | 31536000 | 1 Year. Set to -1 for never |
-| Integer | Channels | RequiredStatusAdmin | 251 | Required status to administer chat channels |
-| Integer | Channels | RequiredStatusListAll | 251 | Required status to list all chat channels |
-| Integer | Channels | DeleteTimer | 1440 | Empty password protected channels will be deleted after this many minutes |
-| Boolean | EventLog | RecordSellToMerchant | FALSE | Record sales from a player to an NPC merchant in eventlog table |
-| Boolean | EventLog | RecordBuyFromMerchant | FALSE | Record purchases by a player from an NPC merchant in eventlog table |
-| Integer | Adventure | MinNumberForGroup | 2 |  |
-| Integer | Adventure | MaxNumberForGroup | 6 |  |
-| Integer | Adventure | MinNumberForRaid | 18 |  |
-| Integer | Adventure | MaxNumberForRaid | 36 |  |
-| Integer | Adventure | MaxLevelRange | 9 |  |
-| Integer | Adventure | NumberKillsForBossSpawn | 45 |  |
-| Decimal | Adventure | DistanceForRescueAccept | 10000 |  |
-| Decimal | Adventure | DistanceForRescueComplete | 2500 |  |
-| Integer | Adventure | ItemIDToEnablePorts | 41000 | 0 to disable, otherwise using a LDoN portal will require the user to have this item. |
-| Integer | Adventure | LDoNTrapDistanceUse | 625 |  |
-| Decimal | Adventure | LDoNBaseTrapDifficulty | 15 |  |
-| Decimal | Adventure | LDoNCriticalFailTrapThreshold | 10 |  |
-| Integer | Adventure | LDoNAdventureExpireTime | 1800 | 30 minutes to expire |
-| Integer | AA | ExpPerPoint | 23976503 | Amount of exp per AA. Is the same as the amount of exp to go from level 51 to level 52. |
-| Boolean | AA | Stacking | TRUE | Allow AA that belong to the same group to stack on SOF+ clients. |
-| Integer | Console | SessionTimeOut | 600000 | Amount of time in ms for the console session to time out |
-| Boolean | QueryServ | PlayerLogChat | FALSE | Logs Player Chat |
-| Boolean | QueryServ | PlayerLogTrades | FALSE | Logs Player Trades |
-| Boolean | QueryServ | PlayerLogHandins | FALSE | Logs Player Handins |
-| Boolean | QueryServ | PlayerLogNPCKills | FALSE | Logs Player NPC Kills |
-| Boolean | QueryServ | PlayerLogDeletes | FALSE | Logs Player Deletes |
-| Boolean | QueryServ | PlayerLogMoves | FALSE | Logs Player Moves |
-| Boolean | QueryServ | PlayerLogMerchantTransactions | FALSE | Logs Merchant Transactions |
-| Boolean | QueryServ | PlayerLogPCCoordinates | FALSE | Logs Player Coordinates with certain events |
-| Boolean | QueryServ | PlayerLogDropItem | FALSE | Logs Player Drop Item |
-| Boolean | QueryServ | PlayerLogZone | FALSE | Logs Player Zone Events |
-| Boolean | QueryServ | PlayerLogDeaths | FALSE | Logs Player Deaths |
-| Boolean | QueryServ | PlayerLogConnectDisconnect | FALSE | Logs Player Connect Disconnect State |
-| Boolean | QueryServ | PlayerLogLevels | FALSE | Logs Player Leveling/Deleveling |
-| Boolean | QueryServ | PlayerLogAARate | FALSE | Logs Player AA Experience Rates |
-| Boolean | QueryServ | PlayerLogQGlobalUpdate | FALSE | Logs Player QGlobal Updates |
-| Boolean | QueryServ | PlayerLogTaskUpdates | FALSE | Logs Player Task Updates |
-| Boolean | QueryServ | PlayerLogKeyringAddition | FALSE | Log PLayer Keyring additions |
-| Boolean | QueryServ | PlayerLogAAPurchases | FALSE | Log Player AA Purchases |
-| Boolean | QueryServ | PlayerLogTradeSkillEvents | FALSE | Log Player Tradeskill Transactions |
-| Boolean | QueryServ | PlayerLogIssuedCommandes | FALSE | Log Player Issued Commands |
-| Boolean | QueryServ | PlayerLogMoneyTransactions | FALSE | Log Player Money Transaction/Splits |
-| Boolean | QueryServ | PlayerLogAlternateCurrencyTransactions | FALSE | Log Ploayer Alternate Currency Transactions |
-| Boolean | Inventory | EnforceAugmentRestriction | TRUE | Forces augment slot restrictions |
-| Boolean | Inventory | EnforceAugmentUsability | TRUE | Forces augmented item usability |
-| Boolean | Inventory | EnforceAugmentWear | TRUE | Forces augment wear slot validation |
-| Boolean | Inventory | DeleteTransformationMold | TRUE | False if you want mold to last forever |
-| Boolean | Inventory | AllowAnyWeaponTransformation | FALSE | Weapons can use any weapon transformation |
-| Boolean | Inventory | TransformSummonedBags | FALSE | Transforms summoned bags into disenchanted ones instead of deleting |
-| Boolean | Client | UseLiveFactionMessage | FALSE | Allows players to see faction adjustments like Live |
-| Boolean | Client | UseLiveBlockedMessage | FALSE | Allows players to see faction adjustments like Live |
-| Boolean | Character | ProcessFearedProximity | FALSE | Process proximity checks while feared. |
+## AA Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| AA:ExpPerPoint |  23976503 | Amount of experience per AA. Is the same as the amount of experience to go from level 51 to level 52 |
+| AA:NormalizedAAEnabled |  false | TSS+ change to AA that normalizes AA experience to a fixed # of white con kills independent of level |
+| AA:NormalizedAANumberOfWhiteConPerAA |  25 | The number of white con kills per AA point |
+| AA:ModernAAScalingEnabled |  false | Are we linearly scaling AA experience based on total # of earned AA? |
+| AA:ModernAAScalingStartPercent |  1000 | 1000% or 10x AA experience at the start of the scaling range |
+| AA:ModernAAScalingAAMinimum |  0 | The minimum number of earned AA before AA experience scaling begins |
+| AA:ModernAAScalingAALimit |  4000 | The number of earned AA when AA experience scaling ends |
+| AA:SoundForAAEarned |  false | Play sound when AA point earned |
 
+## Adventure Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Adventure:MinNumberForGroup |  2 | Minimum members for adventure group |
+| Adventure:MaxNumberForGroup |  6 | Maximum members for adventure group |
+| Adventure:MaxLevelRange |  9 | Maximum level range for adventure |
+| Adventure:NumberKillsForBossSpawn |  45 | Number of adventure kills to make the boss spawn |
+| Adventure:DistanceForRescueAccept |  10000.0 | Distance for adventure rescue accept |
+| Adventure:DistanceForRescueComplete |  2500.0 | Distance for adventure rescue complete |
+| Adventure:ItemIDToEnablePorts |  41000 | ItemID to enable adventure ports. 0 to disable, otherwise using a LDoN portal will require the user to have this item |
+| Adventure:LDoNTrapDistanceUse |  625 | LDoN trap distance use |
+| Adventure:LDoNBaseTrapDifficulty |  15.0 | LDoN base trap difficulty |
+| Adventure:LDoNCriticalFailTrapThreshold |  10.0 | LDoN critical fail trap threshold |
+
+## Aggro Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Aggro:SmartAggroList |  true | Smart aggro list attempts to choose targets in a much smarter fashion, prefering players to pets, sitting and critically injured players to normal players, and players in melee range to players not |
+| Aggro:SittingAggroMod |  35 | Aggro increase against sitting targets. 35=35% |
+| Aggro:MeleeRangeAggroMod |  10 | Aggro increase against targets in melee range. 10=10% |
+| Aggro:CurrentTargetAggroMod |  0 | Aggro increase against current target. 0% = prefer the current target to any other. Makes it harder for our NPC to switch targets |
+| Aggro:CriticallyWoundedAggroMod |  100 | Aggro increase against critical wounded targets |
+| Aggro:SpellAggroMod |  100 | Aggro increase for spells |
+| Aggro:PetSpellAggroMod |  10 | Aggro increase for pet spells |
+| Aggro:TunnelVisionAggroMod |  0.75 | People not currently the top hate generate this much hate on a Tunnel Vision mob |
+| Aggro:MaxScalingProcAggro |  400 | Set to -1 for no limit. Maximum amount of aggro that HP scaling SPA effect in a proc will add |
+| Aggro:IntAggroThreshold |  75 | Int lesser or equal the value will aggro regardless of level difference |
+| Aggro:AllowTickPulling |  false | tick pulling is an exploit in an NPC's call for help fixed sometime in 2006 on live |
+| Aggro:MinAggroLevel |  18 | Minimum level for use with UseLevelAggro |
+| Aggro:UseLevelAggro |  true | MinAggroLevel rule value+ and Undead will aggro regardless of level difference. This will disabled Rule:IntAggroThreshold if set to true |
+| Aggro:ClientAggroCheckMovingInterval |  1000 | Interval in which clients actually check for aggro while moving - in milliseconds - this should be lower than ClientAggroCheckIdleInterval |
+| Aggro:ClientAggroCheckIdleInterval |  6000 | Interval in which clients actually check for aggro while idle - in milliseconds - this should be higher than ClientAggroCheckMovingInterval |
+| Aggro:PetAttackRange |  40000.0 | Maximum squared range /pet attack works at default is 200 |
+| Aggro:NPCAggroMaxDistanceEnabled |  true | If enabled, NPC's will drop aggro beyond 600 units or what is defined at the zone level |
+| Aggro:AggroPlayerPets |  false | If enabled, NPCs will aggro player pets |
+
+## Bazaar Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Bazaar:AuditTrail |  false | Setting whether a path to the trader should be displayed in the bazaar |
+| Bazaar:MaxSearchResults |  50 | Maximum number of search results in Bazaar |
+| Bazaar:EnableWarpToTrader |  true | Setting whether teleport to the selected trader should be active |
+| Bazaar:MaxBarterSearchResults |  200 | The maximum results returned in the /barter search |
+
+## Bots Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Bots:BotExpansionSettings |  16383 | Sets the expansion settings for bot use. Defaults to all expansions enabled up to TSS |
+| Bots:AllowCamelCaseNames |  false | Allows the use of 'MyBot' type names |
+| Bots:CommandSpellRank |  1 | Filters bot command spells by rank. 1, 2 and 3 are valid filters - any other number allows all ranks |
+| Bots:CreationLimit |  150 | Number of bots that each account can create |
+| Bots:FinishBuffing |  false | Allow for buffs to complete even if the bot caster is out of mana. Only affects buffing out of combat |
+| Bots:GroupBuffing |  false | Bots will cast single target buffs as group buffs, default is false for single. Does not make single target buffs work for MGB |
+| Bots:HealRotationMaxMembers |  24 | Maximum number of heal rotation members |
+| Bots:HealRotationMaxTargets |  12 | Maximum number of heal rotation targets |
+| Bots:ManaRegen |  2.0 | Adjust mana regen for bots, 1 is fast and higher numbers slow it down 3 is about the same as players |
+| Bots:PreferNoManaCommandSpells |  true | Give sorting priority to newer no-mana spells (i.e., 'Bind Affinity') |
+| Bots:QuestableSpawnLimit |  false | Optional quest method to manage bot spawn limits using the quest_globals name bot_spawn_limit, see: /bazaar/Aediles_Thrall.pl |
+| Bots:SpawnLimit |  71 | Number of bots a character can have spawned at one time, You + 71 bots is a 12 group pseudo-raid |
+| Bots:BotGroupXP |  false | Determines whether client gets experience for bots outside their group |
+| Bots:BotLevelsWithOwner |  false | Auto-updates spawned bots as owner levels/de-levels (false is original behavior) |
+| Bots:BotCharacterLevel |  0 | If level is greater that value player can spawn bots if BotCharacterLevelEnabled is true |
+| Bots:CasterStopMeleeLevel |  13 | Level at which caster bots stop melee attacks |
+| Bots:AllowOwnerOptionAltCombat |  true | When option is enabled, bots will use an auto-/shared-aggro combat model |
+| Bots:AllowOwnerOptionAutoDefend |  true | When option is enabled, bots will defend their owner on enemy aggro |
+| Bots:LeashDistance |  562500.0f | Distance a bot is allowed to travel from leash owner before being pulled back (squared value) |
+| Bots:AllowApplyPoisonCommand |  true | Allows the use of the bot command 'applypoison' |
+| Bots:AllowApplyPotionCommand |  true | Allows the use of the bot command 'applypotion' |
+| Bots:RestrictApplyPotionToRogue |  true | Restricts the bot command 'applypotion' to rogue-usable potions (i.e., poisons) |
+| Bots:OldRaceRezEffects |  false | Older clients had ID 757 for races with high starting STR, but it doesn't seem used anymore |
+| Bots:ResurrectionSickness |  true | Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness. |
+| Bots:OldResurrectionSicknessSpell |  757 | 757 is Default Old Resurrection Sickness Spell |
+| Bots:ResurrectionSicknessSpell |  756 | 756 is Default Resurrection Sickness Spell |
+
+## Bugs Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Bugs:ReportingSystemActive |  true | Activates bug reporting |
+| Bugs:UseOldReportingMethod |  true | Forces the use of the old bug reporting system |
+| Bugs:DumpTargetEntity |  false | Dumps the target entity, if one is provided |
+
+## Channels Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Channels:RequiredStatusAdmin |  251 | Required status to administer chat channels |
+| Channels:RequiredStatusListAll |  251 | Required status to list all chat channels |
+| Channels:DeleteTimer |  1440 | Empty password protected channels will be deleted after this many minutes |
+
+## Character Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Character:MaxLevel |  65 | Sets the highest level for players that can be reached through experience |
+| Character:PerCharacterQglobalMaxLevel |  false | Check for qglobal 'CharMaxLevel' character qglobal (Type 5, \"\, if player tries to level beyond that point, it will not go beyond that level |
+| Character:PerCharacterBucketMaxLevel |  false | Check for data bucket 'CharMaxLevel', if player tries to level beyond that point, it will not go beyond that level |
+| Character:MaxExpLevel |  0 | Defines the maximum level that can be reached through experience |
+| Character:DeathExpLossLevel |  10 | Any level equal to or greater than this will lose experience at death |
+| Character:DeathExpLossMaxLevel |  255 | Every higher level will no longer lose experience at death |
+| Character:DeathItemLossLevel |  10 | From this level on, items are left in the corpse when LeaveCorpses is activated |
+| Character:DeathExpLossMultiplier |  3 | Adjust how much experience is lost. Default 3.5% (0=0.5%, 1=1.5%, 2=2.5%, 3=3.5%, 4=4.5%, 5=5.5%, 6=6.5%, 7=7.5%, 8=8.5%, 9=9.5%, 10=11%) |
+| Character:UseDeathExpLossMult |  false | Setting to control whether DeathExpLossMultiplier or the code default is used: (Level x Level / 18.0) x 12000 |
+| Character:UseOldRaceRezEffects |  false | Older clients had ID 757 for races with high starting STR, but it doesn't seem used anymore |
+| Character:CorpseDecayTimeMS |  10800000 | Time after which the corpse decays (milliseconds) |
+| Character:CorpseResTimeMS |  10800000 | Time after which the corpse can no longer be resurrected (milliseconds) |
+| Character:LeaveCorpses |  true | Setting whether you leave a corpse behind |
+| Character:LeaveNakedCorpses |  false | Setting whether you leave a corpse without items |
+| Character:MaxDraggedCorpses |  2 | Maximum number of corpses you can drag at once |
+| Character:DragCorpseDistance |  400 | If a player is using /corpsedrag and moving, the corpse will not move until the player exceeds this distance |
+| Character:FinalExpMultiplier |  1 | Added on top of everything else, easy for setting EXP events |
+| Character:ExpMultiplier |  0.5 | If greater than 0, the experience gained is multiplied by this value.  |
+| Character:AAExpMultiplier |  0.5 | If greater than 0, the AA experience gained is multiplied by this value.  |
+| Character:GroupExpMultiplier |  0.5 | The experience in a group is multiplied by this value in addition to the group multiplier. The group multiplier is: 2 members=x 1.2, 3=x1.4, 4=x1.6, 5=x1.8, 6=x2.16 |
+| Character:RaidExpMultiplier |  0.2 | The experience gained in raids is multiplied by (1-RaidExpMultiplier)  |
+| Character:UseXPConScaling |  true | When activated, the experience is modified depending on the difference between player level and NPC level. The values from the rules GreenModifier to RedModifier are used |
+| Character:ShowExpValues |  0 | Show experience values. 0=normal, 1=show raw experience values, 2=show raw experience values and percent |
+| Character:GreenModifier |  20 | The experience obtained for green con mobs is multiplied by value/100 |
+| Character:LightBlueModifier |  40 | The experience obtained for light-blue con mobs is multiplied by value/100 |
+| Character:BlueModifier |  90 | The experience obtained for blue con mobs is multiplied by value/100 |
+| Character:WhiteModifier |  100 | The experience obtained for white con mobs is multiplied by value/100 |
+| Character:YellowModifier |  125 | The experience obtained for yellow con mobs is multiplied by value/100 |
+| Character:RedModifier |  150 | The experience obtained for red con mobs is multiplied by value/100 |
+| Character:AutosaveIntervalS |  300 | Number of seconds after which a timer is triggered which stores the character data. The value 0 means no periodic automatic saving. |
+| Character:HPRegenMultiplier |  100 | The hitpoint regeneration is multiplied by value/100 (up to the caps) |
+| Character:ManaRegenMultiplier |  100 | The mana regeneration is multiplied by value/100 (up to the caps) |
+| Character:EnduranceRegenMultiplier |  100 | The endurance regeneration is multiplied by value/100 (up to the caps) |
+| Character:OldMinMana |  false | This is used for servers that want to follow older skill cap formulas so they can still have some regen w/o mediate |
+| Character:HealOnLevel |  false | Setting whether a player should heal completely when leveling |
+| Character:FeignKillsPet |  false | Setting whether Feign Death kills the player pet |
+| Character:ItemManaRegenCap |  15 | Limit on mana regeneration granted by items |
+| Character:ItemHealthRegenCap |  30 | Limit on health regeneration granted by items |
+| Character:ItemDamageShieldCap |  30 | Limit on damage shields granted by items |
+| Character:ItemAccuracyCap |  150 | Limit on accuracy granted by items |
+| Character:ItemAvoidanceCap |  100 | Limit on avoidance granted by items |
+| Character:ItemCombatEffectsCap |  100 | Limit on combat effects granted by items |
+| Character:ItemShieldingCap |  35 | Limit on shielding granted by items |
+| Character:ItemSpellShieldingCap |  35 | Limit on spell shielding granted by items |
+| Character:ItemDoTShieldingCap |  35 | Limit on DoT shielding granted by items |
+| Character:ItemStunResistCap |  35 | Limit on resistance granted by items |
+| Character:ItemStrikethroughCap |  35 | Limit on strikethrough granted by items |
+| Character:ItemATKCap |  250 | Limit on ATK granted by items |
+| Character:ItemHealAmtCap |  250 | Limit on heal amount granted by items |
+| Character:ItemSpellDmgCap |  250 | Limit on spell damage granted by items |
+| Character:ItemClairvoyanceCap |  250 | Limit on clairvoyance granted by items |
+| Character:ItemDSMitigationCap |  50 | Limit on damageshield mitigation granted by items |
+| Character:ItemEnduranceRegenCap |  15 | Limit on endurance regeneration granted by items |
+| Character:ItemExtraDmgCap |  150 | Cap for bonuses to melee skills like Bash, Frenzy, etc. |
+| Character:HasteCap |  100 | Haste cap for non-v3(over haste) haste |
+| Character:Hastev3Cap |  25 | Haste cap for v3(over haste) haste |
+| Character:SkillUpModifier |  100 | The probability for a skill-up is multiplied by value/100 |
+| Character:SharedBankPlat |  false | Shared bank platinum. Off by default to prevent duplication |
+| Character:BindAnywhere |  false | Allows players to bind their soul anywhere in the world |
+| Character:RestRegenEnabled |  true | Setting to activate out-of-combat regeneration |
+| Character:RestRegenTimeToActivate |  30 | Time in seconds for rest state regen to kick in |
+| Character:RestRegenRaidTimeToActivate |  300 | Time in seconds for rest state regen to kick in with a raid target |
+| Character:KillsPerGroupLeadershipAA |  250 | Minimum number of dark blue mobs that must be killed to get a Group Leadership AA |
+| Character:KillsPerRaidLeadershipAA |  250 | Minimum number of dark blue mobs that must be killed to get a Raid Leadership AAA |
+| Character:MaxFearDurationForPlayerCharacter |  4 | Maximum number of tics a player can be feared. 1 tic equls 6 seconds |
+| Character:MaxCharmDurationForPlayerCharacter |  15 | Maximum number of tics a player can be charmed. 1 tic equls 6 seconds |
+| Character:BaseHPRegenBonusRaces |  4352 | A bitmask of race(s) that receive the regen bonus. Iksar (4096) & Troll (256) = 4352. See common/races.h for the bitmask values |
+| Character:SoDClientUseSoDHPManaEnd |  false | Setting this to true will allow SoD clients to use the SoD HP/Mana/End formulas and previous clients will use the old formulas |
+| Character:UseRaceClassExpBonuses |  true | Setting this to true will enable Class and Racial experience rate bonuses |
+| Character:UseOldRaceExpPenalties |  false | Setting this to true will enable racial experience penalties for Iksar, Troll, Ogre, and Barbarian, as well as the bonus for Halflings |
+| Character:UseOldClassExpPenalties |  false | Setting this to true will enable old class experience penalties for Paladin, SK, Ranger, Bard, Monk, Wizard, Enchanter, Magician, and Necromancer, as well as the bonus for Rogues and Warriors |
+| Character:RespawnFromHover |  false | Setting whether the respawn window should be used |
+| Character:RespawnFromHoverTimer |  300 | Respawn Window countdown timer, in seconds |
+| Character:UseNewStatsWindow |  true | Setting whether the new Stats window, which displays all information, should be used |
+| Character:ItemCastsUseFocus |  false | If true, this allows item clickies to use focuses that have limited maximum levels on them |
+| Character:MinStatusForNoDropExemptions |  80 | This allows status x and higher to trade no drop items |
+| Character:SkillCapMaxLevel |  75 | Sets the Maximum Level used for Skill Caps (from skill_caps table). -1 makes it use MaxLevel rule value. It is set to 75 because PEQ only has skill caps up to that level, and grabbing the players' skill past 75 will return 0, breaking all skills past that level. This helps servers with obsurd level caps (75+ level cap) function without any modifications |
+| Character:StatCap |  0 | If StatCap > 0 then this value is used. If it is 0, the value of the following code is used: If Level < 61: 255. If Level >= 61 and the client SoF or newer: 255 + 5 x (level -60).  If the client is older than SoF and the level < 71 then: 255 + x (level-60). In all other cases: 330. |
+| Character:CheckCursorEmptyWhenLooting |  true | If true, a player cannot loot a corpse (player or NPC) with an item on their cursor |
+| Character:MaintainIntoxicationAcrossZones |  true | If true, alcohol effects are maintained across zoning and logging out/in |
+| Character:EnableDiscoveredItems |  true | If enabled, it enables EVENT_DISCOVER_ITEM and also saves character names and timestamps for the first time an item is discovered |
+| Character:EnableXTargetting |  true | Enable Extended Targeting Window, for users with UF and later clients |
+| Character:EnableAggroMeter |  true | Enable Aggro Meter, for users with RoF and later clients |
+| Character:KeepLevelOverMax |  false | Don't de-level a character that has somehow gone over the level cap |
+| Character:FoodLossPerUpdate |  32 | How much food/water you lose per stamina update |
+| Character:EnableHungerPenalties |  false | Being hungry/thirsty has negative effects -- it does appear normal live servers do not have penalties |
+| Character:EnableFoodRequirement |  true | If disabled, food is no longer required |
+| Character:BaseInstrumentSoftCap |  36 | Softcap for instrument mods, 36 commonly referred to as 3.6 as well |
+| Character:UseSpellFileSongCap |  true | When they removed the AA that increased the cap they removed the above and just use the spell field |
+| Character:BaseRunSpeedCap |  158 | Base Run Speed Cap, on live it's 158% which will give you a runspeed of 1.580 hard capped to 225 |
+| Character:OrnamentationAugmentType |  20 | Ornamentation Augment Type |
+| Character:EnvironmentDamageMulipliter |  1 | Multiplier for environmental damage like fall damage. |
+| Character:UnmemSpellsOnDeath |  true | Setting whether at death all memorized Spells are forgotten |
+| Character:TradeskillUpAlchemy |  2 | Alchemy skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpBaking |  2 | Baking skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpBlacksmithing |  2 | Blacksmithing skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpBrewing |  3 | Brewing skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpFletching |  2 | Fletching skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpJewelcrafting |  2 | Jewelcrafting skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpMakePoison |  2 | Make Poison skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpPottery |  4 | Pottery skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpResearch |  1 | Research skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpTinkering |  2 | Tinkering skillup rate adjustment. Lower is faster |
+| Character:TradeskillUpTailoring |  2 | Tailoring skillup rate adjustment. Lower is faster |
+| Character:MarqueeHPUpdates |  false | Will show health percentage in center of screen if health lesser than 100% |
+| Character:IksarCommonTongue |  95 | Starting value for Common Tongue for Iksars |
+| Character:OgreCommonTongue |  95 | Starting value for Common Tongue for Ogres |
+| Character:TrollCommonTongue |  95 | Starting value for Common Tongue for Trolls |
+| Character:ActiveInvSnapshots |  false | Takes a periodic snapshot of inventory contents from online players |
+| Character:InvSnapshotMinIntervalM |  180 | Minimum time between inventory snapshots (minutes) |
+| Character:InvSnapshotMinRetryM |  30 | Time to re-attempt an inventory snapshot after a failure  (minutes) |
+| Character:InvSnapshotHistoryD |  30 | Time to keep snapshot entries (days) |
+| Character:RestrictSpellScribing |  false | Setting whether to restrict spell scribing to allowable races/classes of spell scroll |
+| Character:UseStackablePickPocketing |  true | Allows stackable pickpocketed items to stack instead of only being allowed in empty inventory slots |
+| Character:AllowMQTarget |  false | Disables putting players in the 'hackers' list for targeting beyond the clip plane or attempting to target something untargetable |
+| Character:UseOldBindWound |  false | Uses the original bind wound behavior |
+| Character:GrantHoTTOnCreate |  false | Grant Health of Target's Target leadership AA on character creation |
+| Character:UseOldConSystem |  false | Setting whether the pre SoF era consider system should be used |
+| Character:OPClientUpdateVisualDebug |  false | Shows a pulse and forward directional particle each time the client sends its position to server |
+| Character:AllowCrossClassTrainers |  false | If the value is true, a player can also train with other class Guildmasters. |
+| Character:PetsUseReagents |  true | Conjuring pets consumes reagents |
+| Character:DismountWater |  true | Dismount horses when entering water |
+| Character:UseNoJunkFishing |  false | Disregards junk items when fishing |
+| Character:SoftDeletes |  true | When characters are deleted in character select, they are only soft deleted |
+| Character:DefaultGuild |  0 | If not 0, new characters placed into the guild # indicated |
+| Character:ProcessFearedProximity |  false | Processes proximity checks when feared |
+| Character:EnableCharacterEXPMods |  false | Enables character zone-based experience modifiers. |
+| Character:PVPEnableGuardFactionAssist |  true | Enables faction based assisting against the aggresor in pvp. |
+| Character:SkillUpFromItems |  true | Allow Skill ups from clickable items |
+| Character:EnableTestBuff |  false | Allow the use of /testbuff |
+| Character:UseResurrectionSickness |  true | Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness. |
+| Character:OldResurrectionSicknessSpellID |  757 | 757 is Default Old Resurrection Sickness Spell ID |
+| Character:ResurrectionSicknessSpellID |  756 | 756 is Default Resurrection Sickness Spell ID |
+| Character:EnableBardMelody |  true | Enable Bard /melody by default, to disable change to false for a classic experience. |
+| Character:EnableRangerAutoFire |  true | Enable Ranger /autofire by default, to disable change to false for a classic experience. |
+| Character:EnableTGB |  true | Enable /tgb (Target Group Buff) by default, to disable change to false for a classic experience. |
+| Character:SkillUpMaximumChancePercentage |  25 | Maximum chance to improve a combat skill, before skill-specific modifiers.  This should be greater than SkillUpMinimumChancePercentage. |
+| Character:SkillUpMinimumChancePercentage |  2 | Minimum chance to improve a combat skill, after skill-specific modifiers.  This should be lesser than SkillUpMaximumChancePercentage. |
+| Character:WarriorTrackingDistanceMultiplier |  0 | If you want warriors to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:ClericTrackingDistanceMultiplier |  0 | If you want clerics to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:PaladinTrackingDistanceMultiplier |  0 | If you want paladins to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:RangerTrackingDistanceMultiplier |  12 | If you want rangers to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:ShadowKnightTrackingDistanceMultiplier |  0 | If you want shadow knights to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:DruidTrackingDistanceMultiplier |  10 | If you want druids to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:MonkTrackingDistanceMultiplier |  0 | If you want monks to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:BardTrackingDistanceMultiplier |  7 | If you want bards to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:RogueTrackingDistanceMultiplier |  0 | If you want rogues to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:ShamanTrackingDistanceMultiplier |  0 | If you want shaman to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:NecromancerTrackingDistanceMultiplier |  0 | If you want necromancers to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:WizardTrackingDistanceMultiplier |  0 | If you want wizards to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:MagicianTrackingDistanceMultiplier |  0 | If you want magicians to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:EnchanterTrackingDistanceMultiplier |  0 | If you want enchanters to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:BeastlordTrackingDistanceMultiplier |  0 | If you want beastlords to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:BerserkerTrackingDistanceMultiplier |  0 | If you want berserkers to be able to track, increase this above 0.  0 disables tracking packets. |
+| Character:OnInviteReceiveAlreadyinGroupMessage |  true | If you want clients to receive a message when trying to invite a player into a group that is currently in another group. |
+
+## Chat Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Chat:ServerWideOOC |  true | Enable server wide ooc-chat |
+| Chat:ServerWideAuction |  true | Enable server wide auction-chat |
+| Chat:EnableVoiceMacros |  true | Enable voice macros |
+| Chat:EnableMailKeyIPVerification |  true | Setting whether the authenticity of the client should be verified via its IP address when accessing the InGame mailbox |
+| Chat:EnableAntiSpam |  true | Enable anti-spam system for chat |
+| Chat:SuppressCommandErrors |  false | Do not suppress command errors by default |
+| Chat:MinStatusToBypassAntiSpam |  100 | Minimum status to bypass the anti-spam system |
+| Chat:MinimumMessagesPerInterval |  4 | Minimum number of chat messages allowed per interval. The karma value is added to this value |
+| Chat:MaximumMessagesPerInterval |  12 | Maximum value of chat messages allowed per interval |
+| Chat:MaxMessagesBeforeKick |  20 | If an attempt is made to send more than the maximum allowed number of chat messages per interval, the client will be disconnected after this absolute number of messages |
+| Chat:IntervalDurationMS |  60000 | Interval length in milliseconds |
+| Chat:KarmaUpdateIntervalMS |  1200000 | Karma update interval in milliseconds |
+| Chat:KarmaGlobalChatLimit |  72 | Amount of karma you need to be able to talk in ooc/auction/chat below the level limit |
+| Chat:GlobalChatLevelLimit |  8 | Level limit you need to of reached to talk in ooc/auction/chat if your karma is too low |
+| Chat:AutoInjectSaylinksToSay |  true | Automatically injects saylinks into dialogue that has [brackets in them] |
+| Chat:AutoInjectSaylinksToClientMessage |  true | Automatically injects saylinks into dialogue that has [brackets in them] |
+| Chat:QuestDialogueUsesDialogueWindow |  false | Pipes all quest dialogue to dialogue window |
+| Chat:DialogueWindowAnimatesNPCsIfNoneSet |  true | If there is no animation specified in the dialogue window markdown then it will choose a random greet animation such as wave or salute |
+
+## Cheat Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Cheat:MQWarpDetectionDistanceFactor |  9.0 | clients move at 4.4 about if in a straight line but with movement and to acct for lag we raise it a bit |
+| Cheat:MQWarpExemptStatus |  -1 | Required status level to exempt the MQWarpDetector. Set to -1 to disable this feature. |
+| Cheat:MQZoneExemptStatus |  -1 | Required status level to exempt the MQZoneDetector. Set to -1 to disable this feature. |
+| Cheat:MQGateExemptStatus |  -1 | Required status level to exempt the MQGateDetector. Set to -1 to disable this feature. |
+| Cheat:MQGhostExemptStatus |  -1 | Required status level to exempt the MQGhostDetector. Set to -1 to disable this feature. |
+| Cheat:MQFastMemExemptStatus |  -1 | Required status level to exempt the MQFastMemDetector. Set to -1 to disable this feature. |
+| Cheat:EnableMQWarpDetector |  true | Enable the MQWarp Detector. Set to False to disable this feature. |
+| Cheat:EnableMQZoneDetector |  true | Enable the MQZone Detector. Set to False to disable this feature. |
+| Cheat:EnableMQGateDetector |  true | Enable the MQGate Detector. Set to False to disable this feature. |
+| Cheat:EnableMQGhostDetector |  true | Enable the MQGhost Detector. Set to False to disable this feature. |
+| Cheat:EnableMQFastMemDetector |  true | Enable the MQFastMem Detector. Set to False to disable this feature. |
+| Cheat:MarkMQWarpLT |  false | Mark clients makeing smaller warps |
+
+## Client Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Client:UseLiveFactionMessage |  false | Allows players to see detailed faction adjustments as on the live servers |
+| Client:UseLiveBlockedMessage |  false | Setting whether detailed spell block messages should be used as on the live servers |
+
+## Combat Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Combat:AERampageSafeZone |  0.018 | max hit ae ramp reduction range |
+| Combat:PetBaseCritChance |  0 | Pet base crit chance |
+| Combat:NPCBashKickLevel |  6 | The level that NPCcan KICK/BASH |
+| Combat:MeleeCritDifficulty |  8900 | Value against which is rolled to check if a melee crit is triggered. Lower is easier |
+| Combat:ArcheryCritDifficulty |  3400 | Value against which is rolled to check if an archery crit is triggered. Lower is easier |
+| Combat:ThrowingCritDifficulty |  1100 | Value against which is rolled to check if a throwing crit is triggered. Lower is easier |
+| Combat:NPCCanCrit |  false | Setting whether an NPC can land critical hits |
+| Combat:UseIntervalAC |  true | Switch whether bonuses, armour class, multipliers, classes and caps should be considered in the calculation of damage values |
+| Combat:PetAttackMagicLevel |  10 | Level at which pets can cause magic damage, no longer used |
+| Combat:NPCAttackMagicLevel |  10 | Level at which NPC and pets can cause magic damage |
+| Combat:EnableFearPathing |  true | Setting whether to use pathing during fear |
+| Combat:FleeGray |  true | If true FleeGrayHPRatio will be used |
+| Combat:FleeGrayHPRatio |  50 | HP percentage when a Gray NPC begins to flee |
+| Combat:FleeGrayMaxLevel |  18 | NPC above this level won't do gray/green con flee |
+| Combat:FleeHPRatio |  25 | HP percentage when a NPC begins to flee |
+| Combat:FleeIfNotAlone |  false | If false, mobs won't flee if other mobs are in combat with it |
+| Combat:AdjustProcPerMinute |  true | Adapt the average proc rate to the speed of the weapon |
+| Combat:AvgProcsPerMinute |  2.0 | Average proc rate per minute |
+| Combat:ProcPerMinDexContrib |  0.075 | Increases the probability of a proc increased by DEX by the value indicated |
+| Combat:BaseProcChance |  0.035 | Base chance for procs |
+| Combat:ProcDexDivideBy |  11000 | Divisor for the probability of a proc increased by dexterity |
+| Combat:MinRangedAttackDist |  25 | Minimum Distance to use Ranged Attacks |
+| Combat:ArcheryBonusRequiresStationary |  true | does the 2x archery bonus chance require a stationary npc |
+| Combat:ArcheryNPCMultiplier |  1.0 | Value is multiplied by the regular dmg to get the archery dmg |
+| Combat:AssistNoTargetSelf |  true | When assisting a target that does not have a target: true = target self, false = leave target as was before assist (false = live like) |
+| Combat:MaxRampageTargets |  3 | Maximum number of people hit with rampage |
+| Combat:DefaultRampageTargets |  1 | Default number of people to hit with rampage |
+| Combat:RampageHitsTarget |  false | Rampage will hit the target if it still has targets left |
+| Combat:MaxFlurryHits |  2 | Maximum number of extra hits from flurry |
+| Combat:MinHastedDelay |  400 | Minimum hasted combat delay |
+| Combat:AvgDefProcsPerMinute |  2.0 | Average defense procs per minute |
+| Combat:DefProcPerMinAgiContrib |  0.075 | How much agility contributes to defensive proc rate |
+| Combat:NPCFlurryChance |  20 | Chance for NPC to flurry |
+| Combat:TauntOverLevel |  1 | Allows you to taunt NPC's over warriors level |
+| Combat:TauntSkillFalloff |  0.33 | For every taunt skill point that's not maxed you lose this percentage chance to taunt |
+| Combat:EXPFromDmgShield |  false | Determine if damage from a damage shield counts for experience gain |
+| Combat:QuiverHasteCap |  1000 | Quiver haste cap 1000 on live for a while, currently 700 on live |
+| Combat:BerserkerFrenzyStart |  35 | Percentage Health Points below which Warrior and Berserker start frenzy |
+| Combat:BerserkerFrenzyEnd |  45 | Percentage Health Points above which Warrior and Berserker end frenzy |
+| Combat:OneProcPerWeapon |  true | If enabled, One proc per weapon per round |
+| Combat:ProjectileDmgOnImpact |  true | If enabled, projectiles (i.e. arrows) will hit on impact, instead of instantly |
+| Combat:MeleePush |  true | Enable melee push |
+| Combat:MeleePushChance |  50 | NPC chance the target will be pushed. Made up, 100 actually isn't that bad |
+| Combat:UseLiveCombatRounds |  true | Turn this false if you don't want to worry about fixing up combat rounds for NPCs |
+| Combat:NPCAssistCap |  5 | Maximum number of NPC that will assist another NPC at once |
+| Combat:NPCAssistCapTimer |  6000 | Time a NPC will take to clear assist aggro cap space (milliseconds) |
+| Combat:UseRevampHandToHand |  false | Use h2h revamped dmg/delays I believe this was implemented during SoF |
+| Combat:ClassicMasterWu |  false | Classic Master Wu uses a random special, modern doesn't |
+| Combat:HitBoxMod |  1.00 | Added to test hit boxes. |
+| Combat:LevelToStopDamageCaps |  0 | Level to stop damage caps. 1 will effectively disable them, 20 should give basically same results as old incorrect system |
+| Combat:LevelToStopACTwinkControl |  50 | Level to stop armorclass twink control. 1 will effectively disable it, 50 should give basically same results as current system |
+| Combat:ClassicNPCBackstab |  false | True disables NPC facestab - NPC get normal attack if not behind |
+| Combat:UseNPCDamageClassLevelMods |  true | Uses GetClassLevelDamageMod calc in npc_scale_manager |
+| Combat:UseExtendedPoisonProcs |  false | Allow old school poisons to last until characrer zones, at a lower proc rate |
+| Combat:EnableSneakPull |  false | Enable implementation of Sneak Pull |
+| Combat:SneakPullAssistRange |  400 | Modified range of assist for sneak pull |
+| Combat:Classic2HBAnimation |  false | 2HB will use the 2 hand piercing animation instead of the overhead slashing animation |
+| Combat:ArcheryConsumesAmmo |  true | Set to false to disable Archery Ammo Consumption |
+| Combat:ThrowingConsumesAmmo |  true | Set to false to disable Throwing Ammo Consumption |
+| Combat:UseLiveRiposteMechanics |  false | Set to true to disable SPA 173 SE_RiposteChance from making those with the effect on them immune to enrage, can longer riposte from a riposte. |
+| Combat:FrontalStunImmunityClasses |  0 | Bitmask for Classes than have frontal stun immunity, No Races (0) by default. |
+| Combat:NPCsUseFrontalStunImmunityClasses |  false | Enable or disable NPCs using frontal stun immunity Classes from Combat:FrontalStunImmunityClasses, false by default. |
+| Combat:FrontalStunImmunityRaces |  512 | Bitmask for Races than have frontal stun immunity, Ogre (512) only by default. |
+| Combat:NPCsUseFrontalStunImmunityRaces |  true | Enable or disable NPCs using frontal stun immunity Races from Combat:FrontalStunImmunityRaces, true by default. |
+
+## Command Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Command:DyeCommandRequiresDyes |  false | Enable this to require a Prismatic Dye (32557) each time someone uses #dye. |
+
+## Console Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Console:SessionTimeOut |  600000 | Amount of time in ms for the console session to time out |
+
+## Doors Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Doors:RequireKeyOnCursor |  false | Enable this to require pre-keyring keys to be on player cursor to open doors. |
+
+## DynamicZone Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| DynamicZone:ClientRemovalDelayMS |  60000 | Delay (milliseconds) until a client is teleported out of dynamic zone after being removed as member |
+| DynamicZone:EmptyShutdownEnabled |  true | Enable early instance shutdown for dynamic zones that have no members |
+| DynamicZone:EmptyShutdownDelaySeconds |  1500 | Seconds to set dynamic zone instance expiration if early shutdown enabled |
+| DynamicZone:EnableInDynamicZoneStatus |  false | Enables the 'In Dynamic Zone' member status in dynamic zone window. If false (live-like) players inside the dynamic zone will show as 'Online' |
+| DynamicZone:WorldProcessRate |  6000 | Timer interval (milliseconds) that systems check their dynamic zone states |
+
+## EventLog Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| EventLog:RecordSellToMerchant |  false | Record sales from a player to an NPC merchant in eventlog table |
+| EventLog:RecordBuyFromMerchant |  false | Record purchases by a player from an NPC merchant in eventlog table |
+
+## Expansion Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Expansion:CurrentExpansion |  -1 | The current expansion enabled for the server [-1 = ALL, 0 = Classic, 1 = Kunark etc.] |
+| Expansion:UseCurrentExpansionAAOnly |  false | When true will only load AA ranks that match CurrentExpansion rule |
+
+## Expedition Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Expedition:MinStatusToBypassPlayerCountRequirements |  80 | Minimum GM status to bypass minimum player requirements for Expedition creation |
+| Expedition:AlwaysNotifyNewLeaderOnChange |  false | Always notify clients when made expedition leader. If false (live-like) new leaders are only notified when made leader via /dzmakeleader |
+| Expedition:LockoutDurationMultiplier |  1.0 | Multiplies lockout duration by this value when new lockouts are added |
+| Expedition:ChooseLeaderCooldownTime |  2000 | Cooldown time (milliseconds) between choosing a new leader for automatic leader changes |
+
+## Faction Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Faction:AllyFactionMinimum |  1100 | Minimum faction for ally |
+| Faction:WarmlyFactionMinimum |  750 | Minimum faction for warmly |
+| Faction:KindlyFactionMinimum |  500 | Minimum faction for kindly |
+| Faction:AmiablyFactionMinimum |  100 | Minimum faction for amiably |
+| Faction:IndifferentlyFactionMinimum |  0 | Minimum faction for indifferently |
+| Faction:ApprehensivelyFactionMinimum |  -100 | Minimum faction for apprehensively |
+| Faction:DubiouslyFactionMinimum |  -500 | Minimum faction for dubiously |
+| Faction:ThreateninglyFactionMinimum |  -750 | Minimum faction for threateningly |
+
+## GM Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| GM:MinStatusToSummonItem |  250 | Minimum required status to summon items |
+| GM:MinStatusToZoneAnywhere |  250 | Minimum required status to zone anywhere |
+| GM:MinStatusToLevelTarget |  100 | Minimum required status to set the level of a player |
+| GM:MinStatusToBypassLockedServer |  100 | Players >= this status can log in to the server even when it is locked |
+| GM:MinStatusToBypassCheckSumVerification |  100 | Players >= this status can bypass the eqgame.exe and spells_us.txt checksum verification |
+
+## Guild Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Guild:PlayerCreationAllowed |  false | Allow players to create a guild using the window in Underfoot+ |
+| Guild:PlayerCreationLimit |  1 | Only allow use of the UF+ window if the account has < than this number of guild leaders on it |
+| Guild:PlayerCreationRequiredStatus |  0 | Required status to create a guild |
+| Guild:PlayerCreationRequiredLevel |  0 | Required level of the player attempting to create the guild |
+| Guild:PlayerCreationRequiredTime |  0 | Time needed online on the account to create a guild (in minutes) |
+
+## HotReload Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| HotReload:QuestsRepopWithReload |  true | When a hot reload is triggered, the zone will repop |
+| HotReload:QuestsRepopWhenPlayersNotInCombat |  true | When a hot reload is triggered, the zone will repop when no clients are in combat |
+| HotReload:QuestsResetTimersWithReload |  true | When a hot reload is triggered, quest timers will be reset |
+| HotReload:QuestsAutoReloadGlobalScripts |  false | When a quest, plugin, or global script changes, auto reload. |
+
+## Instances Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Instances:ReservedInstances |  30 | Number of instance IDs which are reserved for globals. This value should not be changed while a server is running |
+| Instances:RecycleInstanceIds |  true | Setting whether free instance IDs should be recycled to prevent them from gradually running out at 32k |
+| Instances:GuildHallExpirationDays |  90 | Amount of days before a Guild Hall instance expires |
+
+## Inventory Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Inventory:EnforceAugmentRestriction |  true | Forces augment slot restrictions |
+| Inventory:EnforceAugmentUsability |  true | Forces augmented item usability |
+| Inventory:EnforceAugmentWear |  true | Forces augment wear slot validation |
+| Inventory:DeleteTransformationMold |  true | False if you want mold to last forever |
+| Inventory:AllowAnyWeaponTransformation |  false | Weapons can use any weapon transformation |
+| Inventory:TransformSummonedBags |  false | Transforms summoned bags into disenchanted ones instead of deleting |
+| Inventory:AllowMultipleOfSameAugment |  false | Allows multiple of the same augment to be placed in an item via #augmentitem or MQ2, set to true to allow |
+
+## Items Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Items:DisableAttuneable |  false | Enable this to disable Attuneable Items |
+| Items:DisableBardFocusEffects |  false | Enable this to disable Bard Focus Effects on Items |
+| Items:DisableLore |  false | Enable this to disable Lore Items |
+| Items:DisableNoDrop |  false | Enable this to disable No Drop Items |
+| Items:DisableNoPet |  false | Enable this to disable No Pet Items |
+| Items:DisableNoRent |  false | Enable this to disable No Rent Items |
+| Items:DisableNoTransfer |  false | Enable this to disable No Transfer Items |
+| Items:DisablePotionBelt |  false | Enable this to disable Potion Belt Items |
+| Items:DisableSpellFocusEffects |  false | Enable this to disable Spell Focus Effects on Items |
+
+## Logging Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Logging:PrintFileFunctionAndLine |  false | Ex: [World Server] [net.cpp::main:309] Loading variables... |
+| Logging:WorldGMSayLogging |  true | Relay worldserver logging to zone processes via GM say output |
+
+## Mail Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Mail:EnableMailSystem |  true | Setting whether the mail system is activated. If false, client won't bring up the Mail window |
+| Mail:ExpireTrash |  0 | Setting when the mail trash is emptied. Time in seconds. 0 will delete all messages in the trash when the mailserver starts |
+| Mail:ExpireRead |  31536000 | Setting when read mails expire. 31536000=1 Year. Set to -1 for never |
+| Mail:ExpireUnread |  31536000 | Setting when unread mails expire. 31536000=1 Year. Set to -1 for never |
+
+## Map Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Map:FixPathingZOnSendTo |  false | Try to repair Z coordinates in the SendTo routine as well |
+| Map:FixZWhenPathing |  true | Automatically fix NPC Z coordinates when moving/pathing/engaged (Far less CPU intensive than its predecessor) |
+| Map:DistanceCanTravelBeforeAdjustment |  10.0 | Distance a mob can path before FixZ is called, depends on FixZWhenPathing |
+| Map:MobZVisualDebug |  false | Displays spell effects determining whether or not NPC is hitting Best Z calcs (blue for hit, red for miss) |
+| Map:FixPathingZMaxDeltaSendTo |  20 | At runtime in SendTo: maximum change in Z to allow the BestZ code to apply |
+| Map:FindBestZHeightAdjust |  1 | Adds this to the current Z before seeking the best Z position |
+
+## Merchant Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Merchant:UsePriceMod |  true | Use faction/charisma price modifiers |
+| Merchant:SellCostMod |  1.05 | Modifier for NPC sell price |
+| Merchant:BuyCostMod |  0.95 | Modifier for NPC buy price |
+| Merchant:PriceBonusPct |  4 | Determines maximum price bonus from having good faction/CHA. Value is a percent |
+| Merchant:PricePenaltyPct |  4 | Determines maximum price penalty from having bad faction/CHA. Value is a percent |
+| Merchant:ChaBonusMod |  3.45 | Determines CHA cap, from 104 CHA. 3.45 is 132 CHA at apprehensive. 0.34 is 400 CHA at apprehensive |
+| Merchant:ChaPenaltyMod |  1.52 | Determines CHA bottom, up to 102 CHA. 1.52 is 37 CHA at apprehensive. 0.98 is 0 CHA at apprehensive |
+| Merchant:EnableAltCurrencySell |  true | Enables the ability to resell items to alternate currency merchants |
+| Merchant:AllowCorpse |  false | Setting whether dealers leave a corpse behind  |
+
+## Mercs Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Mercs:SuspendIntervalMS |  10000 | Time interval for merc suspend (milliseconds) |
+| Mercs:UpkeepIntervalMS |  180000 | Time interval for merc upkeep (milliseconds) |
+| Mercs:SuspendIntervalS |  10 | Time interval for merc suspend command (seconds) |
+| Mercs:AllowMercs |  false | Allow the use of mercs |
+| Mercs:ChargeMercPurchaseCost |  false | Turns Mercenary purchase costs on or off |
+| Mercs:ChargeMercUpkeepCost |  false | Turns Mercenary upkeep costs on or off |
+| Mercs:AggroRadius |  100 | Determines the distance from which a merc will aggro group member's target(also used to determine the distance at which a healer merc will begin healing a group member) |
+| Mercs:AggroRadiusPuller |  25 | Determines the distance from which a merc will aggro group member's target, if they have the group role of puller (also used to determine the distance at which a healer merc will begin healing a group member, if they have the group role of puller) |
+| Mercs:ResurrectRadius |  50 | Determines the distance from which a healer merc will attempt to resurrect a group member's corpse |
+| Mercs:ScaleRate |  100 | Merc scale factor |
+| Mercs:AllowMercSuspendInCombat |  true | Allow merc suspend in combat |
+
+## NPC Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| NPC:MinorNPCCorpseDecayTimeMS |  450000 | NPC corpse decay time, if NPC below level 55 (milliseconds) |
+| NPC:MajorNPCCorpseDecayTimeMS |  1500000 | NPC corpse decay time, if NPC equal or greater than level 55 (milliseconds) |
+| NPC:CorpseUnlockTimer |  150000 | Time after which corpses are unlocked for everyone to loot (milliseconds) |
+| NPC:EmptyNPCCorpseDecayTimeMS |  0 | NPC corpse decay time, if no items are left on the corpse (milliseconds) |
+| NPC:UseItemBonusesForNonPets |  true | Switch whether item bonuses should be used for NPCs who are not pets |
+| NPC:UseBaneDamage |  false | If NPCs can't inherently hit the target we don't add bane/magic dmg which isn't exactly the same as PCs |
+| NPC:SayPauseTimeInSec |  5 | Time span in which an NPC pauses his movement after a Say event without aggro (seconds) |
+| NPC:OOCRegen |  0 | Enable out-of-combat regeneration for NPC |
+| NPC:BuffFriends |  false | Setting whether NPC should buff other NPC |
+| NPC:EnableNPCQuestJournal |  false | Setting whether the NPC Quest Journal is active |
+| NPC:LastFightingDelayMovingMin |  10000 | Minimum time before mob goes home after all aggro loss (milliseconds) |
+| NPC:LastFightingDelayMovingMax |  20000 | Maximum time before mob goes home after all aggro loss (milliseconds) |
+| NPC:SmartLastFightingDelayMoving |  true | When true, mobs that started going home previously will do so again immediately if still on FD hate list |
+| NPC:ReturnNonQuestNoDropItems |  false | Returns NO DROP items on NPC that don't have an EVENT_TRADE sub in their script |
+| NPC:StartEnrageValue |  9 |  Percentage HP that an NPC will begin to enrage |
+| NPC:LiveLikeEnrage |  false | If set to true then only player controlled pets will enrage |
+| NPC:EnableMeritBasedFaction |  false | If set to true, faction will be given in the same way as experience (solo/group/raid) |
+| NPC:NPCToNPCAggroTimerMin |  500 | Minimum time span after which one NPC aggro another NPC (milliseconds) |
+| NPC:NPCToNPCAggroTimerMax |  6000 | Maximum time span after which one NPC aggro another NPC (milliseconds) |
+| NPC:UseClassAsLastName |  true | Uses class archetype as LastName for NPC with none |
+| NPC:NewLevelScaling |  true | Better level scaling, use old if new formulas would break your server |
+| NPC:NPCGatePercent |  20 |  Percentage at which the NPC Will attempt to gate at |
+| NPC:NPCGateNearBind |  false | Will NPC attempt to gate when near bind location? |
+| NPC:NPCGateDistanceBind |  75 | Distance from bind before NPC will attempt to gate |
+| NPC:NPCHealOnGate |  true | Will the NPC Heal on Gate |
+| NPC:UseMeditateBasedManaRegen |  false | Based NPC ooc regen on Meditate skill |
+| NPC:NPCHealOnGateAmount |  25 | How much the NPC will heal on gate if enabled |
+| NPC:AnimalsOpenDoors |  true | Determines or not whether animals open doors or not when they approach them |
+| NPC:MaxRaceID |  732 | Maximum Race ID, RoF2 by default supports up to 732 |
+| NPC:DisableLastNames |  false | Enable to disable NPC Last Names |
+
+## Network Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Network:ResendDelayBaseMS |  100 | Base delay for resending data in EQStreamManager (milliseconds) |
+| Network:ResendDelayFactor |  1.5 | Multiplier for the base delay when resending data in EQStreamManager |
+| Network:ResendDelayMinMS |  300 | Minimum timespan between two send retries (milliseconds) |
+| Network:ResendDelayMaxMS |  5000 | Maximum timespan between two send retries (milliseconds) |
+| Network:ClientDataRate |  0.0 | KB / sec, 0.0 disabled |
+| Network:CompressZoneStream |  true | Setting whether the zone stream should be compressed for transmission |
+
+## Pathing Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Pathing:Find |  true | Enable pathing for FindPerson requests from the client |
+| Pathing:Fear |  true | Enable pathing for fear |
+| Pathing:NavmeshStepSize |  100.0f | Step size for the movement manager |
+| Pathing:ShortMovementUpdateRange |  130.0f | Range for short movement updates |
+| Pathing:MaxNavmeshNodes |  4092 | Maximum navmesh nodes in a traversable path |
+
+## Pets Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Pets:AttackCommandRange |  150 | Range at which a pet will respond to attack commands |
+| Pets:UnTargetableSwarmPet |  false | Setting whether swarm pets should be targetable |
+| Pets:PetPowerLevelCap |  10 | Maximum number of levels a player pet can go up with pet power |
+| Pets:CanTakeNoDrop |  false | Setting whether anyone can give no-drop items to pets |
+| Pets:LivelikeBreakCharmOnInvis |  true | Default: true will break charm on any type of invis (hide/ivu/iva/etc) false will only break if the pet can not see you (ex. you have an undead pet and cast IVU |
+
+## QueryServ Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| QueryServ:PlayerLogChat |  false | Log player chat |
+| QueryServ:PlayerLogTrades |  false | Log player trades |
+| QueryServ:PlayerDropItems |  false | Log player dropping items |
+| QueryServ:PlayerLogHandins |  false | Log player hand ins |
+| QueryServ:PlayerLogNPCKills |  false | Log player NPC kills |
+| QueryServ:PlayerLogDeletes |  false | Log player deletes |
+| QueryServ:PlayerLogMoves |  false | Log player moves |
+| QueryServ:PlayerLogMerchantTransactions |  false | Log merchant transactions |
+| QueryServ:PlayerLogZone |  false | Log player zone events |
+| QueryServ:PlayerLogDeaths |  false | Log player deaths |
+| QueryServ:PlayerLogConnectDisconnect |  false | Logs player connect/disconnect state |
+| QueryServ:PlayerLogLevels |  false | Log player leveling/deleveling |
+| QueryServ:PlayerLogAARate |  false | Log player AA experience rates |
+| QueryServ:PlayerLogQGlobalUpdate |  false | Log player QGlobal updates |
+| QueryServ:PlayerLogTaskUpdates |  false | Log player Task updates |
+| QueryServ:PlayerLogAAPurchases |  false | Log player AA purchases |
+| QueryServ:PlayerLogTradeSkillEvents |  false | Log player tradeskill transactions |
+| QueryServ:PlayerLogIssuedCommandes |  false | Log player issued commands |
+| QueryServ:PlayerLogAlternateCurrencyTransactions |  false | Log player alternate currency transactions |
+
+## Range Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Range:Say |  15 | The range that is required before /say or hail messages will work to an NPC |
+| Range:Emote |  135 | The packet range in which emote messages are sent' |
+| Range:BeginCast |  200 | The packet range in which begin cast messages are sent |
+| Range:Anims |  135 | The packet range in which begin cast messages are sent |
+| Range:SpellParticles |  135 | The packet range in which spell particles are sent |
+| Range:DamageMessages |  50 | The packet range in which damage messages are sent (non-crit) |
+| Range:SpellMessages |  75 | The packet range in which spell damage messages are sent |
+| Range:SongMessages |  75 | The packet range in which song messages are sent |
+| Range:ClientPositionUpdates |  300 | Distance in which the own changed position is communicated to other clients |
+| Range:CriticalDamage |  80 | The packet range in which critical hit messages are sent |
+| Range:MobCloseScanDistance |  600 | Close scan distance |
+
+## Skills Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Skills:MaxTrainTradeskills |  21 | Highest level for trading skills that can be learnt by the trainer |
+| Skills:UseLimitTradeskillSearchSkillDiff |  true | Enables the limit for the maximum difference between trivial and skill for recipe searches and favorites |
+| Skills:MaxTradeskillSearchSkillDiff |  50 | The maximum difference in skill between the trivial of an item and the skill of the player if the trivial is higher than the skill. Recipes that have not been learnt or made at least once via the Experiment mode will be removed from searches based on this criteria. |
+| Skills:MaxTrainSpecializations |  50 | Maximum level a GM trainer will train casting specializations |
+| Skills:SwimmingStartValue |  100 | Start value of swimming skill |
+| Skills:TrainSenseHeading |  false | Switch whether SenseHeading is trained by use |
+| Skills:SenseHeadingStartValue |  200 | Start value of sense heading skill |
+| Skills:SelfLanguageLearning |  true | Enabling self-learning of languages |
+| Skills:RequireTomeHandin |  false | Disable click-to-learn and force hand in to Guild Master |
+
+## Spells Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Spells:BaseCritChance |  0 | Base percentage chance that everyone has to crit a spell |
+| Spells:BaseCritRatio |  100 | Base percentage bonus to damage on a successful spell crit. 100=2xdamage |
+| Spells:WizCritLevel |  12 | Level wizards first get spell crits |
+| Spells:WizCritChance |  7 | Wizards crit chance, on top of BaseCritChance |
+| Spells:WizCritRatio |  0 | Wizards crit bonus, on top of BaseCritRatio (should be 0 for Live-like) |
+| Spells:TranslocateTimeLimit |  0 | If not zero, time in seconds to accept a Translocate |
+| Spells:SacrificeMinLevel |  46 | First level the spell Sacrifice will work on |
+| Spells:SacrificeMaxLevel |  69 | Last level the spell Sacrifice will work on |
+| Spells:SacrificeItemID |  9963 | Item ID of the item Sacrifice will return (defaults to an Essence Emerald) |
+| Spells:EnableSpellGlobals |  false | If enabled, spells check the spell_globals table and compare character data from their quest globals before allowing the spell to scribe with scribespells/traindiscs |
+| Spells:EnableSpellBuckets |  false | If enabled, spells check the spell_buckets table and compare character data from their data buckets before allowing the spell to scribe with scribespells/traindiscs |
+| Spells:MaxBuffSlotsNPC |  60 | Maximum number of NPC buff slots. The default value is the limit of the Titanium client |
+| Spells:MaxSongSlotsNPC |  0 | Maximum number of NPC song slots. NPC don't have songs, so it should be 0 |
+| Spells:MaxDiscSlotsNPC |  0 | Maximum number of NPC disc slots. NPC don't have discs, so it should be 0 |
+| Spells:MaxTotalSlotsNPC |  60 | Maximum total of NPC slots. The default value is the limit of the Titanium client |
+| Spells:MaxTotalSlotsPET |  30 | Maximum total of pet slots. The default value is the limit of the Titanium client |
+| Spells:ReflectType |  4 | Reflect type. 0=disabled, 1=single target player spells only, 2=all player spells, 3=all single target spells, 4=all spells |
+| Spells:ReflectMessagesClose |  true | True (Live functionality) is for Reflect messages to show to players within close proximity. False shows just player reflecting |
+| Spells:LiveLikeFocusEffects |  true | Determines whether specific healing, dmg and mana reduction focuses are randomized |
+| Spells:BaseImmunityLevel |  55 | The level that targets start to be immune to stun, fear and mez spells with a maximum level of 0 |
+| Spells:NPCIgnoreBaseImmunity |  true | Whether or not NPC get to ignore the BaseImmunityLevel for their spells |
+| Spells:AvgSpellProcsPerMinute |  6.0 | Adjust rate for sympathetic spell procs |
+| Spells:ResistFalloff |  67 | Maximum that level that will adjust our resist chance based on level modifiers |
+| Spells:CharismaEffectiveness |  10 | Determines how much resist modification charisma applies to charm/pacify checks. Default 10 CHA = -1 resist mod |
+| Spells:CharismaEffectivenessCap |  255 | Determines how much resist modification charisma applies to charm/pacify checks. Default 10 CHA = -1 resist mod |
+| Spells:CharismaCharmDuration |  false | Allow CHA resist mod to extend charm duration |
+| Spells:CharmBreakCheckChance |  25 | Determines chance for a charm break check to occur each buff tick |
+| Spells:CharmDisablesSpecialAbilities |  false | When charm is cast on an NPC, strip their special abilities |
+| Spells:RootBreakFromSpells |  55 | Chance for root to break when cast on |
+| Spells:DeathSaveCharismaMod |  3 | Determines how much charisma effects chance of death save firing |
+| Spells:DivineInterventionHeal |  8000 | Divine intervention heal amount |
+| Spells:AdditiveBonusWornType |  0 | Calc worn bonuses to add together (instead of taking highest) if set to THIS worn type. (2=Will covert live items automatically) |
+| Spells:UseCHAScribeHack |  false | ScribeSpells and TrainDiscs quest functions will ignore entries where field 12 is CHA |
+| Spells:BuffLevelRestrictions |  true | Buffs will not land on low level toons like live |
+| Spells:RootBreakCheckChance |  70 | Determines chance for a root break check to occur each buff tick |
+| Spells:FearBreakCheckChance |  70 | Determines chance for a fear break check to occur each buff tick |
+| Spells:SuccorFailChance |  2 | Determines chance for a succor spell not to teleport an invidual player |
+| Spells:FRProjectileItem_Titanium |  1113 | Item id for Titanium clients for Fire 'spell projectile' |
+| Spells:FRProjectileItem_SOF |  80684 | Item id for SOF clients for Fire 'spell projectile' |
+| Spells:FRProjectileItem_NPC |  80684 | Item id for NPC Fire 'spell projectile' |
+| Spells:UseLiveSpellProjectileGFX |  false | Use spell projectile graphics set in the spells_new table (player_1). Server must be using UF+ spell file |
+| Spells:FocusCombatProcs |  false | Allow all combat procs to receive focus effects |
+| Spells:PreNerfBardAEDoT |  false | Allow bard AOE dots to damage targets when moving |
+| Spells:AI_SpellCastFinishedFailRecast |  800 | AI spell recast time  when an spell is cast but fails, ie if stunned (milliseconds) |
+| Spells:AI_EngagedNoSpellMinRecast |  500 | AI spell recast time check when no spell is cast while engaged. Min time in random (milliseconds) |
+| Spells:AI_EngagedNoSpellMaxRecast |  1000 | AI spell recast time check when no spell is cast engaged. Mmaximum time in random (milliseconds) |
+| Spells:AI_EngagedBeneficialSelfChance |  100 | Chance during first AI Cast check to do a beneficial spell on self |
+| Spells:AI_EngagedBeneficialOtherChance |  25 | Chance during second AI Cast check to do a beneficial spell on others |
+| Spells:AI_EngagedDetrimentalChance |  20 | Chance during third AI Cast check to do a determental spell on others |
+| Spells:AI_PursueNoSpellMinRecast |  500 | AI spell recast time check when no spell is cast while chasing target. Mmin time in random (milliseconds) |
+| Spells:AI_PursueNoSpellMaxRecast |  2000 | AI spell recast time check when no spell is cast while chasing target. Maximum time in random (milliseconds) |
+| Spells:AI_PursueDetrimentalChance |  90 | Chance while chasing target to cast a detrimental spell |
+| Spells:AI_IdleNoSpellMinRecast |  6000 | AI spell recast time check when no spell is cast while idle. Mmin time in random (milliseconds) |
+| Spells:AI_IdleNoSpellMaxRecast |  60000 | AI spell recast time check when no spell is cast while chasing target. Maximum time in random (milliseconds) |
+| Spells:AI_IdleBeneficialChance |  100 | Chance while idle to do a beneficial spell on self or others |
+| Spells:AI_HealHPPct |  50 | Hitpoint percentage at which NPC starts healing when max_hp of the spell is not set (inside and outside combat) |
+| Spells:SHDProcIDOffByOne |  true | Pre June 2009 SHD spell procs were off by 1, they stopped doing this in June 2009 (UF+ spell files need this false) |
+| Spells:Jun182014HundredHandsRevamp |  false | This should be true for if you import a spell file newer than June 18, 2014 |
+| Spells:SwarmPetTargetLock |  false | Use old method of swarm pets target locking till target dies then despawning |
+| Spells:NPC_UseFocusFromSpells |  true | Allow NPC to use most spell derived focus effects |
+| Spells:NPC_UseFocusFromItems |  false | Allow NPC to use most item derived focus effects |
+| Spells:UseAdditiveFocusFromWornSlot |  false | Allows an additive focus effect to be calculated from worn slot |
+| Spells:AlwaysSendTargetsBuffs |  false | Ignore Leadership Alternate Abilities level if true |
+| Spells:FlatItemExtraSpellAmt |  false | Allow SpellDmg stat to affect all spells, regardless of cast time/cooldown/etc |
+| Spells:IgnoreSpellDmgLvlRestriction |  false | Ignore the 5 level spread on applying SpellDmg |
+| Spells:ItemExtraSpellAmtCalcAsPercent |  false | Apply the Item stats Spell Dmg and Heal Amount as Percentage-based modifiers instead of flat additions |
+| Spells:AllowItemTGB |  false | Target group buff (/tgb) doesn't work with items on live, custom servers want it though |
+| Spells:NPCInnateProcOverride |  true | NPC innate procs override the target type to single target |
+| Spells:OldRainTargets |  false | Use old incorrectly implemented maximum targets for rains |
+| Spells:NPCSpellPush |  false | Enable spell push on NPCs |
+| Spells:July242002PetResists |  true | Enable Pets using PCs resist change from July 24 2002 |
+| Spells:AOEMaxTargets |  0 | Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit. |
+| Spells:CazicTouchTargetsPetOwner |  true | If True, causes Cazic Touch to swap targets from pet to pet owner if a pet is tanking. |
+| Spells:PreventFactionWarOnCharmBreak |  false | Enable spell interupts and dot removal on charm break to prevent faction wars. |
+| Spells:AllowDoubleInvis |  true | Allows you to cast invisibility spells on a player that is already invisible, live like behavior. |
+| Spells:AllowSpellMemorizeFromItem |  false | Allows players to memorize spells by right-clicking spell scrolls |
+| Spells:InvisRequiresGroup |  false | Invis requires the the target to be in group. |
+| Spells:ClericInnateHealFocus |  5 | Clerics on live get a 5 pct innate heal focus |
+| Spells:DOTsScaleWithSpellDmg |  false | Allow SpellDmg stat to affect DoT spells |
+| Spells:HOTsScaleWithHealAmt |  false | Allow HealAmt stat to affect HoT spells |
+| Spells:CompoundLifetapHeals |  true | True: Lifetap heals calculate damage bonuses and then heal bonuses.  False:  Lifetaps heal using the amount damaged to mob. |
+| Spells:UseFadingMemoriesMaxLevel |  false | Enables to limit field in spell data to set the max level that over which an NPC will ignore fading memories effect and not lose aggro. |
+| Spells:FixBeaconHeading |  false | Beacon spells use casters heading to fix live bug.  False: Live like heading always 0. |
+| Spells:UseSpellImpliedTargeting |  false | Replicates EQ2-style targeting behavior for spells. Spells will 'pass through' inappropriate targets to target's target if it is appropriate. |
+| Spells:BuffsFadeOnDeath |  true | Disable to keep buffs from fading on death |
+| Spells:IllusionsAlwaysPersist |  false | Allows Illusions to persist beyond death and zoning always. |
+
+## TaskSystem Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| TaskSystem:EnableTaskSystem |  true | Globally enable or disable the Task system |
+| TaskSystem:PeriodicCheckTimer |  5 | Seconds between checks for failed tasks. Also used by the 'Touch' activity |
+| TaskSystem:RecordCompletedTasks |  true | Record completed tasks |
+| TaskSystem:RecordCompletedOptionalActivities |  false | Record completed optional activities |
+| TaskSystem:KeepOneRecordPerCompletedTask |  true | Keep only one record per completed task |
+| TaskSystem:EnableTaskProximity |  true | Enable task proximity system |
+| TaskSystem:RequestCooldownTimerSeconds |  15 | Seconds between allowing characters to request tasks (live-like default: 15 seconds) |
+
+## Watermap Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Watermap:CheckForWaterOnSendTo |  false | Checks if a mob has moved into/out of water on SendTo |
+| Watermap:CheckForWaterWhenFishing |  false | Only lets a player fish near water (if a water map exists for the zone) |
+| Watermap:FishingRodLength |  30 | How far in front of player water must be for fishing to work |
+| Watermap:FishingLineLength |  100 | If water is more than this far below the player, it is considered too far to fish |
+| Watermap:FishingLineStepSize |  1 | Basic step size for fishing calc, too small and it will eat cpu, too large and it will miss potential water |
+
+## World Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| World:ZoneAutobootTimeoutMS |  60000 | Time out for automatic booting of zones in milliseconds |
+| World:UseBannedIPsTable |  false | Toggle whether or not to check incoming client connections against the banned_ips table. Set this value to false to disable this feature |
+| World:EnableTutorialButton |  true | Setting whether the Tutorial button should be active. At least in RoF2 you can always press the button, but it loses its effect |
+| World:EnableReturnHomeButton |  true | Setting whether the Return Home button should be active |
+| World:MaxLevelForTutorial |  10 | The highest level with which you can enter the tutorial |
+| World:TutorialZoneID |  189 | Zone ID of the tutorial |
+| World:GuildBankZoneID |  345 | Zone ID of the guild bank |
+| World:MinOfflineTimeToReturnHome |  21600 | Minimum offline time to activate the Return Home button. 21600 seconds is 6 Hours |
+| World:MaxClientsPerIP |  -1 | Maximum number of clients allowed to connect per IP address if account status is < AddMaxClientsStatus. Default value: -1 (feature disabled) |
+| World:ExemptMaxClientsStatus |  -1 | Exempt accounts from the MaxClientsPerIP and AddMaxClientsStatus rules, if their status is >= this value. Default value: -1 (feature disabled) |
+| World:AddMaxClientsPerIP |  -1 | Maximum number of clients allowed to connect per IP address if account status is < ExemptMaxClientsStatus. Default value: -1 (feature disabled) |
+| World:AddMaxClientsStatus |  -1 | Accounts with status >= this rule will be allowed to use the amount of accounts defined in the AddMaxClientsPerIP. Default value: -1 (feature disabled) |
+| World:MaxClientsSetByStatus |  false | If true, IP Limiting will be set to the status on the account as long as the status is > MaxClientsPerIP |
+| World:EnableIPExemptions |  false | If true, ip_exemptions table is used, if there is no entry for the IP it will default to RuleI(World, MaxClientsPerIP) |
+| World:ClearTempMerchantlist |  true | Clears temp merchant items when world boots |
+| World:GMAccountIPList |  false | Check IP list against GM accounts. This increases the security of GM accounts, e.g. if you only allow localhost '127.0.0.1' for GM accounts. Think carefully about what you enter! |
+| World:MinGMAntiHackStatus |  1 | Minimum status to check against AntiHack list |
+| World:SoFStartZoneID |  -1 | Sets the Starting Zone for SoF Clients separate from Titanium Clients (-1 is disabled) |
+| World:TitaniumStartZoneID |  -1 | Sets the Starting Zone for Titanium Clients (-1 is disabled). Replaces the old method |
+| World:ExpansionSettings |  16383 | Sets the expansion settings for the server, This is sent on login to world and affects client expansion settings. Defaults to all expansions enabled up to TSS, value is bitmask |
+| World:UseClientBasedExpansionSettings |  true | If true it will overrule World, ExpansionSettings and set someone's expansion based on the client they're using |
+| World:PVPSettings |  0 | Sets the PVP settings for the server. 1=Rallos Zek RuleSet, 2=Tallon/Vallon Zek Ruleset, 4=Sullon Zek Ruleset, 6=Discord Ruleset, anything above 6 is the Discord Ruleset without the no-drop restrictions removed. NOTE: edit IsAttackAllowed in Zone-table to accomodate for these rules |
+| World:PVPMinLevel |  0 | Minimum level to pvp |
+| World:StartZoneSameAsBindOnCreation |  true | Should the start zone always be the same location as your bind? |
+| World:EnforceCharacterLimitAtLogin |  false | Enforce the limit for characters that are online at login |
+| World:EnableDevTools |  true | Enable or Disable the Developer Tools globally (Most of the time you want this enabled) |
+| World:EnableChecksumVerification |  false | Enable or Disable the Checksum Verification for eqgame.exe and spells_us.txt |
+
+## Zone Rules
+| Rule Name | Default Value | Description |
+| :--- | :--- | :--- |
+| Zone:ClientLinkdeadMS |  90000 | The time a client remains link dead on the server after a sudden disconnection (milliseconds) |
+| Zone:GraveyardTimeMS |  1200000 | Time until a player corpse is moved to a zone's graveyard, if one is specified for the zone (milliseconds) |
+| Zone:EnableShadowrest |  1 | Enables or disables the Shadowrest zone feature for player corpses. Default is turned on |
+| Zone:AutoShutdownDelay |  5000 | How long a dynamic zone stays loaded while empty (milliseconds) |
+| Zone:PEQZoneReuseTime |  900 | Seconds between two uses of the #peqzone command (Set to 0 to disable) |
+| Zone:PEQZoneDebuff1 |  4454 | First debuff casted by #peqzone Default is Cursed Keeper's Blight |
+| Zone:PEQZoneDebuff2 |  2209 | Second debuff casted by #peqzone Default is Tendrils of Apathy |
+| Zone:UsePEQZoneDebuffs |  true | Setting if the command #peqzone applies the defined debuffs |
+| Zone:PEQZoneHPRatio |  75 | Required HP Ratio to use #peqzone |
+| Zone:HotZoneBonus |  0.75 | Value which is added to the experience multiplier. This also applies to AA experience. |
+| Zone:EbonCrystalItemID |  40902 | Item ID for Ebon Crystal |
+| Zone:RadiantCrystalItemID |  40903 | Item ID for Radiant Crystal |
+| Zone:LevelBasedEXPMods |  false | Allows you to use the level_exp_mods table in consideration to your players experience hits |
+| Zone:WeatherTimer |  600 | Weather timer when no duration is available |
+| Zone:EnableLoggedOffReplenishments |  true | 'Replenish mana/hp/end if logged off for MinOfflineTimeToReplenishments |
+| Zone:MinOfflineTimeToReplenishments |  21600 | Minimum time a player must be offline before LoggedOffReplenishments becomes active (seconds) |
+| Zone:UseZoneController |  true | Enables the ability to use persistent quest based zone controllers (zone_controller.pl/lua) |
+| Zone:EnableZoneControllerGlobals |  false | Enables the ability to use quest globals with the zone controller NPC |
+| Zone:GlobalLootMultiplier |  1 | Sets Global Loot drop multiplier for database based drops, useful for double, triple loot etc |
+| Zone:KillProcessOnDynamicShutdown |  true | When process has booted a zone and has hit its zone shut down timer, it will hard kill the process to free memory back to the OS |
+| Zone:SecondsBeforeIdle |  60 | Seconds before IDLE_WHEN_EMPTY define kicks in |
+| Zone:SpawnEventMin |  3 | When strict is set in spawn_events, specifies the max EQ minutes into the trigger hour a spawn_event will fire. Going below 3 may cause the spawn_event to not fire. |

--- a/internal/console/boot.go
+++ b/internal/console/boot.go
@@ -13,6 +13,7 @@ func Run() error {
 		NewQuestApiDocGeneratorCommand().Command(),
 		NewDbGenerateDocsCommand().Command(),
 		NewGMCommandsDocsGenerateCommand().Command(),
+		NewServerRulesDocsGenerateCommand().Command(),
 	}
 
 	cmd.AddCommand(commands...)

--- a/internal/console/command_doc_generator_cmd.go
+++ b/internal/console/command_doc_generator_cmd.go
@@ -59,38 +59,27 @@ func (c *GMCommandsDocsGenerateCommand) Handle(_ *cobra.Command, _ []string) {
 	generatedTime := currentTime.Format("2006.01.02")
 	template = strings.ReplaceAll(template, "{{generated_time}}", generatedTime)
 
-	commandData := template + "\n"
+	commandData := fmt.Sprintf("%v\n", template)
 
 	commandData += "| Command | Description | Status Level |\n"
 
-	commandData = fmt.Sprintf("%v| :--- | :--- | :--- |\n", commandData)
+	commandData += "| :--- | :--- | :--- |\n"
 
 	for _, line := range strings.Split(string(body), "\n") {
 		if strings.Contains(line, "command_add(\"") {
-
-			//pp.Println(line)
-
 			line = strings.ReplaceAll(line, "command_add(", "")
 			line = strings.ReplaceAll(line, "\t", "")
 
 			lineData := strings.Split(line, "\", ")
 
-			// command
 			command := strings.TrimSpace(lineData[0])
 			command = strings.ReplaceAll(command, "\"", "")
 
-			// help
 			help := strings.TrimSpace(lineData[1])
 			help = strings.ReplaceAll(help, "\"", "")
 			help = strings.ReplaceAll(help, "|", "&#124;")
 
-			// account status
 			accountStatus := getStringInBetween(line, "AccountStatus::", ",")
-
-			//pp.Println(lineData)
-			//pp.Println(command)
-			//pp.Println(help)
-			//pp.Println(accountStatus)
 
 			statusValue := GetStatusValue(accountStatus)
 

--- a/internal/console/server_rules_doc_generator_cmd.go
+++ b/internal/console/server_rules_doc_generator_cmd.go
@@ -1,0 +1,115 @@
+package console
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type ServerRulesDocsGenerateCommand struct {
+	command *cobra.Command
+}
+
+func (c *ServerRulesDocsGenerateCommand) Command() *cobra.Command {
+	return c.command
+}
+
+func NewServerRulesDocsGenerateCommand() *ServerRulesDocsGenerateCommand {
+	i := &ServerRulesDocsGenerateCommand{
+		command: &cobra.Command{
+			Use:   "doc:server-rules",
+			Short: "Command used for generated Server Rules Documentation",
+		},
+	}
+
+	i.command.Args = i.Validate
+	i.command.Run = i.Handle
+
+	return i
+}
+
+func (c *ServerRulesDocsGenerateCommand) Validate(_ *cobra.Command, _ []string) error {
+	return nil
+}
+
+func (c *ServerRulesDocsGenerateCommand) Handle(_ *cobra.Command, _ []string) {
+	resp, err := http.Get("https://raw.githubusercontent.com/EQEmu/Server/master/common/ruletypes.h")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	b, err := ioutil.ReadFile("./templates/server-rules-page.template")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	template := string(b)
+
+	currentTime := time.Now()
+	generatedTime := currentTime.Format("2006.01.02")
+	template = strings.ReplaceAll(template, "{{generated_time}}", generatedTime)
+
+	serverRulesCategoryData := make(map[string]string)
+
+	serverRulesData := fmt.Sprintf("%v\n", template)
+
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, "RULE_BOOL(") || strings.HasPrefix(line, "RULE_INT(") || strings.HasPrefix(line, "RULE_REAL(") {
+			currentLine := strings.ReplaceAll(line, "RULE_BOOL", "")
+			currentLine = strings.ReplaceAll(currentLine, "RULE_INT", "")
+			currentLine = strings.ReplaceAll(currentLine, "RULE_REAL", "")
+
+			lineData := strings.Split(currentLine, ", \"")
+
+			currentServerRuleData := strings.Split(lineData[0], ",")
+			ruleType := strings.ReplaceAll(currentServerRuleData[0], "(", "")
+			ruleName := strings.ReplaceAll(currentServerRuleData[1], " ", "")
+			ruleName = fmt.Sprintf("%v:%v", ruleType, ruleName)
+			ruleDefaultValue := currentServerRuleData[2]
+			ruleDesc := strings.ReplaceAll(lineData[1], "\")", "")
+			ruleDesc = strings.ReplaceAll(ruleDesc, "|", "&#124;")
+
+			serverRulesCategoryData[ruleType] += fmt.Sprintf("| %v | %v | %v |\n", ruleName, ruleDefaultValue, ruleDesc)
+		}
+	}
+
+	keys := make([]string, 0)
+
+	for k, _ := range serverRulesCategoryData {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, serverRuleType := range keys {
+		serverRulesData += fmt.Sprintf("## %v Rules\n", serverRuleType)
+
+		serverRulesData += "| Rule Name | Default Value | Description |\n"
+
+		serverRulesData += "| :--- | :--- | :--- |\n"
+
+		lineEnding := "\n"
+
+		if serverRuleType == keys[len(keys)-1] {
+			lineEnding = ""
+		}
+
+		serverRulesData += fmt.Sprintf("%v%v", serverRulesCategoryData[serverRuleType], lineEnding)
+	}
+
+	err = os.WriteFile("./docs/server/operation/server-rules.md", []byte(serverRulesData), os.ModePerm)
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/templates/server-rules-page.template
+++ b/templates/server-rules-page.template
@@ -1,0 +1,21 @@
+---
+description: >-
+  This page describes the Rules and Rule Values for your EQEmu Server. These
+  rules are found in the rule_values table.
+---
+
+# Server Rules
+
+### Editing rules
+
+To edit rules, you can use the [`#rules set [Name] [Value]`](https://docs.eqemu.io/server/operation/in-game-command-reference) command to set a rule. 
+
+You can then use [`#reload rules`](https://docs.eqemu.io/server/operation/loading-server-data/) to force all zones to reload the new rules. 
+
+!!! warning
+      The `notes` field in the database is set by the server software.  If you adjust the values in the field, they will be overwritten and restored to default values when you update your server binaries.
+
+
+!!! info
+      If you would like to improve upon the descriptions or notes in the Server Rules table, please submit a pull request on the [ruletypes](https://github.com/EQEmu/Server/blob/master/common/ruletypes.h) header file.
+


### PR DESCRIPTION
- Add Server Rules documentation generator.
- Splits rules in to categories and lists categories alphabetically.
- Small cleanup in Command Generator to use fmt.Sprintf where useful.
![image](https://user-images.githubusercontent.com/89047260/172724514-18e2ad69-8f96-49c3-84b1-2f95878416a6.png)
![image](https://user-images.githubusercontent.com/89047260/172724554-e00eb3c1-48d5-4afb-b3e5-ee51362edb58.png)
