### PR TITLE
Update door-open-types.md

### DIFF
--- a/docs/server/zones/door-open-types.md
+++ b/docs/server/zones/door-open-types.md
@@ -13,7 +13,7 @@
 | 6 | normal 90 degree door swing forward |  |
 | 7 | normal 90 degree door swing forward |  |
 | 8 | normal 90 degree door swing backward |  |
-| 9 | nothing |  |
+| 9 | no movement, click events will only fire once  |  |
 | 10 | slides forward |  |
 | 11 | slides forward |  |
 | 12 | slides forward |  |


### PR DESCRIPTION
opentype 9 was labeled as "nothing" but I noticed click events only seem to fire once with that open type until a relog or #reload static occurs