### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,13 +45,13 @@ for EverQuest built mostly on C / C++**
 
 Find us on Discord!
 
-<iframe src="https://discord.com/widget?id=212663220849213441&theme=dark" width="300" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+<iframe src="https://discord.com/widget?id=1421535813031821376&theme=dark" width="300" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
 
 ## Bug Reports
 
 * Please use the [issue tracker](https://github.com/EQEmu/Server/issues) provided by GitHub to send us bug reports or
   feature requests.
-* [Discord](https://discord.gg/QHsm7CD) is also a place to get more immediate help from community members on
+* [Discord](https://discord.gg/pX7Duv9djP) is also a place to get more immediate help from community members on
   troubleshooting
 
 ## External Resource links


### PR DESCRIPTION
Update Discord Community Links to Tanaan Discord

This commit updates all Discord server references throughout the documentation to point to the new official Tanaan community Discord server, replacing the previous EQEmulator Discord server links.

## Changes Made

### Discord Widget
- Updated Discord server widget ID from `212663220849213441` to the New Tanaan Discord server ID
- The embedded Discord widget on the documentation homepage now displays the active New Tanaan community server

### Discord Invite Links
- Replaced invite link `https://discord.gg/QHsm7CD` with the New Tanaan Discord invite link
- All references to joining the Discord community now direct users to the New Tanaan server

## Files Modified

- `docs/index.md` - Updated Discord widget and invite links on homepage

## Additional Notes

This change is part of the community's transition to the new Tanaan Discord server. Users visiting the documentation will now be directed to the correct, actively maintained Discord community for support and engagement.