### PR TITLE
Fix URL of akk-stack on linux server installation page

### DIFF
--- a/docs/server/installation/server-installation-linux.md
+++ b/docs/server/installation/server-installation-linux.md
@@ -1,5 +1,4 @@
 # Linux Server Installer
 
 !!! warning
-     The Linux Installer is currently not working, it is suggested to use [https://github.com/Akkadius/akk-stack](../../akk-stack/introduction.md) as a much better alternative for now until the installer is addressed.
-
+     The Linux Installer is currently not working, it is suggested to use [https://github.com/EQEmu/akk-stack](../../akk-stack/introduction.md) as a much better alternative for now until the installer is addressed.


### PR DESCRIPTION
While the link URL does lead to a helpful page, the text of the link references the old address of the akk-stack repo, which could be confusing.  This updates it to the EQEmu version.